### PR TITLE
Corrected Cozy Camper revert info to Pre-Matchmaking

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -184,7 +184,7 @@ public void OnPluginStart() {
 	ItemDefine("Chargin' Targe", "targe", "Reverted to pre-toughbreak, 40% blast resistance, afterburn immunity");
 	ItemDefine("Claidheamh Mòr", "claidheamh", "Reverted to pre-toughbreak, -15 health, no damage vulnerability");
 	ItemDefine("Cleaner's Carbine", "carbine", "Reverted to release, crits for 3 seconds on kill");
-	ItemDefine("Cozy Camper","cozycamper","Reverted to pre-inferno, flinch resist at any charge level");
+	ItemDefine("Cozy Camper","cozycamper","Reverted to pre-matchmaking, flinch resist at any charge level");
 	ItemDefine("Crit-a-Cola", "critcola", "Reverted to pre-matchmaking, +25% movespeed, +10% damage taken, no mark-for-death on attack");
 	ItemDefine("Dead Ringer", "ringer", "Reverted to pre-gunmettle, can pick up ammo, 80% dmg resist for 4s");
 	ItemDefine("Degreaser", "degreaser", "Reverted to pre-toughbreak, full switch speed for all weapons, old penalties");


### PR DESCRIPTION
https://wiki.teamfortress.com/wiki/Cozy_Camper
July 7, 2016 Patch #1 (Meet Your Match Update)
    Changed attribute:
        Now requires a full charge to gain flinch resistance.

MyM really killed the game even more huh