### PR TITLE
Black box fix for disguised Spy and Ubered enemy

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2682,8 +2682,8 @@ Action SDKHookCB_OnTakeDamage(
 					GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 1085) &&
 					attacker != victim &&
 					TF2_GetClientTeam(attacker) != TF2_GetClientTeam(victim) &&
-					TF2_IsPlayerInCondition(victim, TFCond_Disguised) == false &&
-					TF2_IsPlayerInCondition(victim, TFCond_Ubercharged) == false
+					!TF2_IsPlayerInCondition(victim, TFCond_Disguised) &&
+					!TF2_IsPlayerInCondition(victim, TFCond_Ubercharged)
 					// reverted black box will heal on Bonked Scouts
 					// for some reason adding TF2_IsPlayerInCondition(victim, TFCond_Bonked) makes the healing not work
 				) {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2681,7 +2681,11 @@ Action SDKHookCB_OnTakeDamage(
 					(GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 228 ||
 					GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 1085) &&
 					attacker != victim &&
-					TF2_GetClientTeam(attacker) != TF2_GetClientTeam(victim)
+					TF2_GetClientTeam(attacker) != TF2_GetClientTeam(victim) &&
+					TF2_IsPlayerInCondition(victim, TFCond_Disguised) == false &&
+					TF2_IsPlayerInCondition(victim, TFCond_Ubercharged) == false
+					// reverted black box will heal on Bonked Scouts
+					// for some reason adding TF2_IsPlayerInCondition(victim, TFCond_Bonked) makes the healing not work
 				) {
 					// Show that attacker got healed.
 					Handle event = CreateEvent("player_healonhit", true);


### PR DESCRIPTION
Added if checks for when a Spy is disguised and when an enemy is Ubered to not heal the attacker

"The Soldier will not receive health if the target is a disguised Spy or an enemy under the effects of an ÜberCharge; however, health will still be awarded if the target is a Scout under the effects of Bonk! Atomic Punch. "

https://wiki.teamfortress.com/w/index.php?title=Black_Box&oldid=1922390

Note: only tested on bots using addcond commands in itemtest - if checks not tested yet if it works on rockets reflected by Pyros.