### PR TITLE
improved deadringer revert

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -868,6 +868,7 @@ public void OnGameFrame() {
 						if (players[idx].spy_is_feigning == false) {
 							if (TF2_IsPlayerInCondition(idx, TFCond_DeadRingered)) {
 								players[idx].spy_is_feigning = true;
+								players[idx].damage_taken_during_feign = 0.0;
 							}
 						} else {
 							if (
@@ -912,6 +913,17 @@ public void OnGameFrame() {
 						}
 
 						players[idx].spy_cloak_meter = cloak;
+					}
+
+					{
+						// deadringer cancel condition when feign buff ends
+						
+						if (
+							TF2_IsPlayerInCondition(idx, TFCond_DeadRingered) &&
+							GetFeignBuffsEnd(idx) >= GetGameTickCount()
+						) {
+							TF2_RemoveCondition(idx, TFCond_DeadRingered);
+						}
 					}
 
 					{
@@ -1207,7 +1219,7 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 
 					TF2_RemoveCondition(client, TFCond_SpeedBuffAlly);
 				}
-
+				
 				if (
 					condition == TFCond_AfterburnImmune &&
 					TF2_IsPlayerInCondition(client, TFCond_FireImmune) == false // didn't use spycicle

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -916,17 +916,6 @@ public void OnGameFrame() {
 					}
 
 					{
-						// deadringer cancel condition when feign buff ends
-						
-						if (
-							TF2_IsPlayerInCondition(idx, TFCond_DeadRingered) &&
-							GetFeignBuffsEnd(idx) >= GetGameTickCount()
-						) {
-							TF2_RemoveCondition(idx, TFCond_DeadRingered);
-						}
-					}
-
-					{
 						// spycicle recharge
 
 						if (ItemIsEnabled("spycicle")) {
@@ -2431,6 +2420,8 @@ Action SDKHookCB_OnTakeDamage(
 				) {
 					damage *= 0.10;
 					return Plugin_Changed;
+				} else {
+					TF2_RemoveCondition(victim, TFCond_DeadRingered);
 				}
 			}
 		}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -916,6 +916,17 @@ public void OnGameFrame() {
 					}
 
 					{
+						// deadringer cancel condition when feign buff ends
+						if (
+							players[idx].spy_is_feigning &&
+							GetFeignBuffsEnd(idx) < GetGameTickCount() &&
+							TF2_IsPlayerInCondition(idx, TFCond_DeadRingered)
+						) {
+							TF2_RemoveCondition(idx, TFCond_DeadRingered);
+						}
+					}
+
+					{
 						// spycicle recharge
 
 						if (ItemIsEnabled("spycicle")) {
@@ -2411,15 +2422,6 @@ Action SDKHookCB_OnTakeDamage(
 				
 				if (players[victim].spy_is_feigning) {
 					players[victim].damage_taken_during_feign += damage;
-				}
-				
-				// move this check elsewhere
-				if (
-					players[victim].spy_is_feigning &&
-					GetFeignBuffsEnd(victim) < GetGameTickCount() &&
-					TF2_IsPlayerInCondition(victim, TFCond_DeadRingered)
-				) {
-					TF2_RemoveCondition(victim, TFCond_DeadRingered);
 				}
 			}
 		}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2391,7 +2391,7 @@ Action SDKHookCB_OnTakeDamage(
 							SetConVarFloat(cvar_ref_tf_feign_death_duration, 6.5);
 							SetConVarFloat(cvar_ref_tf_feign_death_speed_duration, 6.5);
 							SetConVarFloat(cvar_ref_tf_feign_death_activate_damage_scale, 0.10);
-							SetConVarFloat(cvar_ref_tf_feign_death_damage_scale, 1.0);
+							SetConVarFloat(cvar_ref_tf_feign_death_damage_scale, 0.10);
 						} else {
 							SetConVarReset(cvar_ref_tf_feign_death_duration);
 							SetConVarReset(cvar_ref_tf_feign_death_speed_duration);
@@ -2401,8 +2401,7 @@ Action SDKHookCB_OnTakeDamage(
 					}
 				}
 				
-				// dead ringer dmg mods
-				// NOTE! MOVE THIS TO A BETTER PLACE!
+				// dead ringer damage tracking
 				if (
 					GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&
 					players[victim].spy_is_feigning == false
@@ -2414,13 +2413,12 @@ Action SDKHookCB_OnTakeDamage(
 					players[victim].damage_taken_during_feign += damage;
 				}
 				
+				// move this check elsewhere
 				if (
 					players[victim].spy_is_feigning &&
-					GetFeignBuffsEnd(victim) >= GetGameTickCount()
+					GetFeignBuffsEnd(victim) < GetGameTickCount() &&
+					TF2_IsPlayerInCondition(victim, TFCond_DeadRingered)
 				) {
-					damage *= 0.10;
-					return Plugin_Changed;
-				} else {
 					TF2_RemoveCondition(victim, TFCond_DeadRingered);
 				}
 			}


### PR DESCRIPTION
Uses code from notnheavy's pre-gunmettle plugin
This PR only changes the damage resist and duration (does not address clientside speedboost sound or ammo logic)

Misc changes:

- Attribute 726 (cloak_consume_on_feign_death_activate) changed to 1.0 so that the inspectpanel shows 0% lost instead of 90% lost. The attribute seems to only be cosmetic and does not affect the function itself