### PR TITLE
(Revert) tide turner resistance change for historical accuracy + my name

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -239,7 +239,7 @@ public void OnPluginStart() {
 	ItemDefine("Spy-cicle", "spycicle", "Reverted to pre-gunmettle, fire immunity for 2s, silent killer");
 	ItemDefine("Sticky Jumper", "stkjumper", "Can have 8 stickies out at once again");
 	ItemDefine("Sydney Sleeper", "sleeper", "Reverted to pre-2018, restored jarate explosion, no headshots");
-	ItemDefine("Tide Turner", "turner", "Reverted to gunmettle, deal full crits like other shields again, 25% fire resist and 25% blast resist");
+	ItemDefine("Tide Turner", "turner", "Reverted to pre-tough break, deal full crits like other shields again, 25% fire resist and 25% blast resist");
 	ItemDefine("Tribalman's Shiv", "tribalshiv", "Reverted to release, 8 second bleed, 35% damage penalty");
 	ItemDefine("Ullapool Caber", "caber", "Reverted to pre-gunmettle, always deals 175+ damage on melee explosion");
 	ItemDefine("Vita-Saw", "vitasaw", "Reverted to pre-inferno, always preserves up to 20% uber on death");

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -20,7 +20,7 @@
 
 #define PLUGIN_NAME "TF2 Weapon Reverts"
 #define PLUGIN_DESC "Reverts nerfed weapons back to their glory days"
-#define PLUGIN_AUTHOR "Bakugo, random, huutti, VerdiusArcana"
+#define PLUGIN_AUTHOR "Bakugo, random, huutti, VerdiusArcana, MindfulProtons"
 #define PLUGIN_VERSION "1.3.2"
 #define PLUGIN_URL "https://steamcommunity.com/profiles/76561198020610103"
 
@@ -239,7 +239,7 @@ public void OnPluginStart() {
 	ItemDefine("Spy-cicle", "spycicle", "Reverted to pre-gunmettle, fire immunity for 2s, silent killer");
 	ItemDefine("Sticky Jumper", "stkjumper", "Can have 8 stickies out at once again");
 	ItemDefine("Sydney Sleeper", "sleeper", "Reverted to pre-2018, restored jarate explosion, no headshots");
-	ItemDefine("Tide Turner", "turner", "Can deal full crits like other shields again");
+	ItemDefine("Tide Turner", "turner", "Reverted to gunmettle, deal full crits like other shields again, 25% fire resist and 25% blast resist");
 	ItemDefine("Tribalman's Shiv", "tribalshiv", "Reverted to release, 8 second bleed, 35% damage penalty");
 	ItemDefine("Ullapool Caber", "caber", "Reverted to pre-gunmettle, always deals 175+ damage on melee explosion");
 	ItemDefine("Vita-Saw", "vitasaw", "Reverted to pre-inferno, always preserves up to 20% uber on death");
@@ -1777,8 +1777,10 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 	) {
 		item1 = TF2Items_CreateItem(0);
 		TF2Items_SetFlags(item1, (OVERRIDE_ATTRIBUTES|PRESERVE_ATTRIBUTES));
-		TF2Items_SetNumAttributes(item1, 1);
+		TF2Items_SetNumAttributes(item1, 3);
 		TF2Items_SetAttribute(item1, 0, 676, 0.0); // lose demo charge on damage when charging
+		TF2Items_SetAttribute(item1, 1, 60, 0.75); // 25% fire damage resistance on wearer
+		TF2Items_SetAttribute(item1, 2, 64, 0.75); // 25% explosive damage resistance on wearer
 	}
 
 	else if (


### PR DESCRIPTION
Pre-Tough Break Tide Turner used to have 25% fire and 25% explosive damage resistances on the wearer and full crits. The one we have in the reverts servers has 15%, which is historically inaccurate. 

My charge meter while charging doesn't decrease if I get hit by my own blasts and if I get fall damage. The plugin code also states the amount of charge taken away on damage when charging is 1 per point of damage.
Thus, this version of the Tide Turner we have in the plugin is actually the Gun Mettle/pre-Tough Break version.

**Unfortunately this still has the new shield bash feature from the Tough Break update, where the shield bash deals damage at all ranges and is scaled by distance, which I think is harder to implement.**

https://wiki.teamfortress.com/w/index.php?title=Tide_Turner&oldid=1932148

[December 22, 2014 Patch](https://wiki.teamfortress.com/wiki/December_22,_2014_Patch) ([Smissmas 2014](https://wiki.teamfortress.com/wiki/Smissmas_2014))
    Changed attributes:
        Added Penalty: Taking damage while shield charging reduces remaining charging time.
        Kills while charging now only add 75% meter on charge kills instead of 100%.

[July 2, 2015 Patch](https://wiki.teamfortress.com/wiki/July_2,_2015_Patch) #1 ([Gun Mettle Update](https://wiki.teamfortress.com/wiki/Gun_Mettle_Update))
    Updated description to better detail the weapon's features.
    Changed attributes:
        Self damage will no longer decrease charge when charging.
        Fall damage will no longer decrease charge when charging.
        Amount of charge taken away on damage when charging reduced from 3 to 1 per point of damage.
        [Undocumented] Changed 75 charge on charge kill to 75 charge on melee kill.

[December 17, 2015 Patch](https://wiki.teamfortress.com/wiki/December_17,_2015_Patch) ([Tough Break Update](https://wiki.teamfortress.com/wiki/Tough_Break_Update))
    Changed attributes:
        Shield bash now deals damage at all ranges, scaled by distance.
        Melee damage boost after shield bash is based on amount of charge consumed. Now provides Mini-Crit at 25% depleted.
        Charging now removes debuffs from the Demoknight (Bleed, Fire, Mad Milk, Jarate).
        Now grants Mini-Crit instead of full-Crit on charge bash.
        Reduced resistances to 15%.