### PR TITLE
Rework Soda Popper to use minicrit visuals

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -737,8 +737,7 @@ public void OnGameFrame() {
 								) {
 									if (GetEntPropFloat(idx, Prop_Send, "m_flHypeMeter") >= 99.5) {
 										// Fall back to hype condition if the player has a drink item
-										bool has_lunchbox = PlayerHasItem(idx, "tf_weapon_lunchbox_drink", 46) ||
-															PlayerHasItem(idx, "tf_weapon_lunchbox_drink", 163);
+										bool has_lunchbox = PlayerHasItem(idx, "tf_weapon_lunchbox_drink", -1);
 										TF2_AddCondition(idx, has_lunchbox ? TFCond_CritHype : TFCond_CritCola, 10.0, 0);
 										players[idx].is_under_hype = has_lunchbox ? false : true;
 									}
@@ -2197,8 +2196,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 
 			if (players[client].is_under_hype)
 			{
-				bool has_lunchbox = PlayerHasItem(client, "tf_weapon_lunchbox_drink", 46) ||
-									PlayerHasItem(client, "tf_weapon_lunchbox_drink", 163);
+				bool has_lunchbox = PlayerHasItem(client, "tf_weapon_lunchbox_drink", -1);
 				if (has_lunchbox)
 				{
 					players[client].is_under_hype = false;
@@ -3140,7 +3138,8 @@ bool PlayerHasItem(int client, char[] classname, int item_index) {
 			int index = GetEntProp(weapon,Prop_Send,"m_iItemDefinitionIndex");
 			if(
 				StrEqual(classname, class) &&
-				(item_index == index)
+				((item_index == index) ||
+				 (item_index == -1))
 			) {
 				return true;
 			}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -235,7 +235,7 @@ public void OnPluginStart() {
 	ItemDefine("Scottish Resistance", "scottish", "Reverted to release, 0.4 arm time penalty (from 0.8), no fire rate bonus");
 	ItemDefine("Short Circuit", "circuit", "Reverted to post-gunmettle, alt fire destroys projectiles, -cost +speed");
 	ItemDefine("Shortstop", "shortstop", "Reverted reload time to release version, with +40% push force");
-	ItemDefine("Soda Popper", "sodapop", "Reverted to pre-2013, run to build hype and auto gain minicrits");
+	ItemDefine("Soda Popper", "sodapop", "Reverted to pre-Smissmas 2013, run to build hype and auto gain minicrits");
 	ItemDefine("Solemn Vow", "solemn", "Reverted to pre-gunmettle, firing speed penalty removed");
 	ItemDefine("Spy-cicle", "spycicle", "Reverted to pre-gunmettle, fire immunity for 2s, silent killer");
 	ItemDefine("Sticky Jumper", "stkjumper", "Can have 8 stickies out at once again");
@@ -713,7 +713,7 @@ public void OnGameFrame() {
 							TF2_IsPlayerInCondition(idx, TFCond_CritHype) == false
 						) {
 							// allow mini-crit buff to last indefinitely
-							// if player is under hype but the cond was removed (e.g. via resupply), re-add it
+							// if player is under minicrits but the cond was removed (e.g. via resupply), re-add it
 
 							if (TF2_IsPlayerInCondition(idx, TFCond_CritCola)) {
 								SetEntPropFloat(idx, Prop_Send, "m_flEnergyDrinkMeter", 100.0);
@@ -761,6 +761,7 @@ public void OnGameFrame() {
 									}
 								}
 
+								// hype meter drain on minicrit condition
 								if (players[idx].is_under_hype) {
 									hype = GetEntPropFloat(idx, Prop_Send, "m_flHypeMeter");
 									

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -98,6 +98,7 @@ enum struct Player {
 	int max_health;
 	int ticks_since_feign_ready;
 	float damage_taken_during_feign;
+	bool is_under_hype;
 }
 
 //item sets
@@ -658,7 +659,7 @@ public void OnGameFrame() {
 					}
 
 					{
-						// mini-crit buff lasts indefinitely
+						// allow mini-crit buff to last indefinitely
 
 						if (TF2_IsPlayerInCondition(idx, TFCond_CritCola)) {
 							SetEntPropFloat(idx, Prop_Send, "m_flEnergyDrinkMeter", 90.0);
@@ -724,10 +725,11 @@ public void OnGameFrame() {
 
 								if (
 									StrEqual(class, "tf_weapon_soda_popper") &&
-									TF2_IsPlayerInCondition(idx, TFCond_CritHype) == false
+									players[idx].is_under_hype == false
 								) {
-									if (GetEntPropFloat(idx, Prop_Send, "m_flHypeMeter") >= 100.0) {
-										TF2_AddCondition(idx, TFCond_CritHype, 10.0, 0);
+									if (GetEntPropFloat(idx, Prop_Send, "m_flHypeMeter") >= 99.5) {
+										TF2_AddCondition(idx, TFCond_CritCola, 10.0, 0);
+										players[idx].is_under_hype = true;
 									}
 
 									if (
@@ -748,9 +750,26 @@ public void OnGameFrame() {
 										SetEntPropFloat(idx, Prop_Send, "m_flHypeMeter", hype);
 									}
 								}
+
+								if (players[idx].is_under_hype) {
+									hype = GetEntPropFloat(idx, Prop_Send, "m_flHypeMeter");
+									
+									if (hype <= 0.0)
+									{
+										players[idx].is_under_hype = false;
+									}
+									else
+									{
+										hype -= 10 * GetTickInterval();
+										SetEntPropFloat(idx, Prop_Send, "m_flHypeMeter", hype);
+									}
+								}
 							}
 						}
 					}
+				} else {
+					// reset if player isn't scout
+					players[idx].is_under_hype = false;
 				}
 
 				if (TF2_GetPlayerClass(idx) == TFClass_Soldier) {
@@ -1033,6 +1052,7 @@ public void OnGameFrame() {
 				players[idx].spy_is_feigning = false;
 				players[idx].scout_airdash_value = 0;
 				players[idx].scout_airdash_count = 0;
+				players[idx].is_under_hype = false;
 			}
 		}
 	}
@@ -2586,6 +2606,7 @@ Action SDKHookCB_OnTakeDamage(
 				}
 			}
 
+			/*
 			{
 				// soda popper minicrits
 
@@ -2597,6 +2618,7 @@ Action SDKHookCB_OnTakeDamage(
 					TF2_AddCondition(victim, TFCond_MarkedForDeathSilent, 0.001, 0);
 				}
 			}
+			*/
 
 			{
 				// sandman stun

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -736,10 +736,11 @@ public void OnGameFrame() {
 									TF2_IsPlayerInCondition(idx, TFCond_CritHype) == false
 								) {
 									if (GetEntPropFloat(idx, Prop_Send, "m_flHypeMeter") >= 99.5) {
-										// Fall back to hype condition if the player has Crit-a-Cola
-										bool has_critcola = PlayerHasItem(idx, "tf_weapon_lunchbox_drink", 163);
-										TF2_AddCondition(idx, has_critcola ? TFCond_CritHype : TFCond_CritCola, 10.0, 0);
-										players[idx].is_under_hype = has_critcola ? false : true;
+										// Fall back to hype condition if the player has a drink item
+										bool has_lunchbox = PlayerHasItem(idx, "tf_weapon_lunchbox_drink", 46) ||
+															PlayerHasItem(idx, "tf_weapon_lunchbox_drink", 163);
+										TF2_AddCondition(idx, has_lunchbox ? TFCond_CritHype : TFCond_CritCola, 10.0, 0);
+										players[idx].is_under_hype = has_lunchbox ? false : true;
 									}
 
 									if (
@@ -2192,13 +2193,13 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 		}
 
 		{
-			// if player has crit-a-cola, end minicrits and apply hype
+			// if player has a drink item, end minicrits and apply hype
 
 			if (players[client].is_under_hype)
 			{
-				bool has_critcola = PlayerHasItem(client, "tf_weapon_lunchbox_drink", 163);
-
-				if (has_critcola)
+				bool has_lunchbox = PlayerHasItem(client, "tf_weapon_lunchbox_drink", 46) ||
+									PlayerHasItem(client, "tf_weapon_lunchbox_drink", 163);
+				if (has_lunchbox)
 				{
 					players[client].is_under_hype = false;
 					TF2_AddCondition(client, TFCond_CritHype, 10.0, 0);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -658,6 +658,14 @@ public void OnGameFrame() {
 					}
 
 					{
+						// mini-crit buff lasts indefinitely
+
+						if (TF2_IsPlayerInCondition(idx, TFCond_CritCola)) {
+							SetEntPropFloat(idx, Prop_Send, "m_flEnergyDrinkMeter", 90.0);
+						}
+					}
+
+					{
 						// shortstop shove
 
 						if (ItemIsEnabled("shortstop")) {


### PR DESCRIPTION
Note: The code falls back to the hype purple glow when having a drink item equipped (Bonk, Crit-a-Cola), so it doesn't conflict with them