### PR TITLE
Update offsets in reverts.txt to fix bugs.

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -30,20 +30,20 @@
 		{
 			"CTFWeaponBase::PrimaryAttack"
 			{
-				"linux" "292"
-				"windows" "286"
-			}
-
-			"CTFWeaponBase::SecondaryAttack"
-			{
 				"linux" "293"
 				"windows" "287"
 			}
 
+			"CTFWeaponBase::SecondaryAttack"
+			{
+				"linux" "294"
+				"windows" "288"
+			}
+
 			"CTFBaseRocket::GetRadius"
 			{
-				"linux" "244"
-				"windows" "243"
+				"linux" "245"
+				"windows" "244"
 			}
 		}
 


### PR DESCRIPTION
Offsets needed updating in the "Offsets" section in reverts.txt

This fixes the rocket launcher shenanigans and additionally also fixes 
so the short circuit revert works again.

Credits to random for getting the ball rolling and protons for extensive help with testing.