### PR TITLE
(bug fix) move deadringer damage tracking to OnTakeDamagePost

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1036,7 +1036,6 @@ public void OnGameFrame() {
 						if (players[idx].spy_is_feigning == false) {
 							if (TF2_IsPlayerInCondition(idx, TFCond_DeadRingered)) {
 								players[idx].spy_is_feigning = true;
-								players[idx].damage_taken_during_feign = 0.0;
 							}
 						} else {
 							if (
@@ -2632,17 +2631,14 @@ Action SDKHookCB_OnTakeDamage(
 					}
 				}
 				
-				// dead ringer damage tracking
+				// dead ringer track when feign begins
 				if (ItemIsEnabled("ringer")) {
 					if (
 						GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&
 						players[victim].spy_is_feigning == false
 					) {
 						players[victim].ticks_since_feign_ready = GetGameTickCount();
-					}
-					
-					if (players[victim].spy_is_feigning) {
-						players[victim].damage_taken_during_feign += damage;
+						players[victim].damage_taken_during_feign  = 0.0;
 					}
 				}
 			}
@@ -3210,6 +3206,17 @@ void SDKHookCB_OnTakeDamagePost(
 	int victim, int attacker, int inflictor, float damage, int damage_type,
 	int weapon, float damage_force[3], float damage_position[3], int damage_custom
 ) {
+	if (
+		victim >= 1 &&
+		victim <= MaxClients &&
+		TF2_GetPlayerClass(victim) == TFClass_Spy
+	) {
+		// dead ringer damage tracking
+		if (TF2_IsPlayerInCondition(victim, TFCond_DeadRingered)) {
+			players[victim].damage_taken_during_feign += damage;
+		}
+	}
+
 	if (
 		victim >= 1 && victim <= MaxClients &&
 		attacker >= 1 && attacker <= MaxClients


### PR DESCRIPTION
fixes the duration reduction for deadringered spies being damaged by e.g. Caber or Enforcer