### PR TITLE
(Fix) Base Jumper Fire Updraft

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1202,9 +1202,6 @@ public void OnGameFrame() {
 
 						if (TF2_IsPlayerInCondition(idx, TFCond_Parachute)) {
 							players[idx].parachute_cond_time = GetGameTime();
-							
-							// By setting tf_parachute_maxspeed_onfire_z = 10.0, fire updraft is back again. Valve set this to -100 for some reason by default.
-							SetConVarFloat(cvar_ref_tf_parachute_maxspeed_onfire_z, 10.0);	
 
 							if (
 								ItemIsEnabled("basejump") &&
@@ -1297,6 +1294,8 @@ public void OnGameFrame() {
 			SetConVarMaybe(cvar_ref_tf_bison_tick_time, "0.001", ItemIsEnabled("bison"));
 			SetConVarMaybe(cvar_ref_tf_fireball_radius, "30.0", ItemIsEnabled("dragonfury"));
 			SetConVarMaybe(cvar_ref_tf_parachute_aircontrol, "5", ItemIsEnabled("basejump"));
+			// By setting tf_parachute_maxspeed_onfire_z = 10.0, fire updraft is back again. Valve set this to -100 for some reason by default.
+			SetConVarMaybe(cvar_ref_tf_parachute_maxspeed_onfire_z, "10.0", ItemIsEnabled("basejump"));	
 		}
 	}
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1202,6 +1202,9 @@ public void OnGameFrame() {
 
 						if (TF2_IsPlayerInCondition(idx, TFCond_Parachute)) {
 							players[idx].parachute_cond_time = GetGameTime();
+							
+							// By setting tf_parachute_maxspeed_onfire_z = 10.0, fire updraft is back again. Valve set this to -100 for some reason by default.
+							SetConVarFloat(cvar_ref_tf_parachute_maxspeed_onfire_z, 10.0);	
 
 							if (
 								ItemIsEnabled("basejump") &&


### PR DESCRIPTION
Valve Dev Wiki states that tf_parachute_maxspeed_onfire_z should be 10.0f by default, but for some reason, tf_parachute_maxspeed_onfire_z got set to -100.0f by default by Valve (same value used for tf_parachute_maxspeed_z) after the recent patches in May 2025, which broke the fire updraft revert. 
(Source: https://developer.valvesoftware.com/wiki/List_of_Team_Fortress_2_console_commands_and_variables)

As for how I determined tf_parachute_maxspeed_onfire_z to be -100.0, I printed out its float value (and also for pos1[2]) into the server console.

By setting tf_parachute_maxspeed_onfire_z = 10.0, fire updraft is back again.