### PR TITLE
(Revert) Pre-Pyromania Tomislav

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2105,6 +2105,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		TF2Items_SetNumAttributes(item1, 2);
 		TF2Items_SetAttribute(item1, 0, 87, 0.60); // 40% minigun spinup time decreased; mult_minigun_spinup_time
 		TF2Items_SetAttribute(item1, 1, 106, 1.0); // 0% accuracy attribute; weapon spread bonus; mult_spread_scale
+		// Note: It is recommended for the minigun ramp-up revert to be active so that the reverted pre-Pyromania Tomislav is historically and functionally accurate!
 	}
 
 	else if (

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -357,6 +357,7 @@ public void OnPluginStart() {
 	ItemDefine("Sticky Jumper", "stkjumper", "Reverted to Pyromania update, can have 8 stickybombs out at once again", CLASSFLAG_DEMOMAN);
 	ItemDefine("Sydney Sleeper", "sleeper", "Reverted to pre-2018, restored jarate explosion, no headshots", CLASSFLAG_SNIPER);
 	ItemDefine("Tide Turner", "turner", "Reverted to pre-toughbreak, can deal full crits, 25% blast and fire resist, crit after bash, no debuff removal", CLASSFLAG_DEMOMAN);
+	ItemDefine("Tomislav", "tomislav", "Reverted to pre-pyromania, 40% faster spinup, no accuracy bonus, no barrel spin sound, 20% slower firing speed", CLASSFLAG_HEAVY);	
 	ItemDefine("Tribalman's Shiv", "tribalshiv", "Reverted to release, 8 second bleed, 35% damage penalty", CLASSFLAG_SNIPER);
 	ItemDefine("Ullapool Caber", "caber", "Reverted to pre-gunmettle, always deals 175+ damage on melee explosion", CLASSFLAG_DEMOMAN);
 	ItemDefine("Vita-Saw", "vitasaw", "Reverted to pre-inferno, always preserves up to 20% uber on death", CLASSFLAG_MEDIC);
@@ -2092,6 +2093,18 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		TF2Items_SetNumAttributes(item1, 2);
 		TF2Items_SetAttribute(item1, 0, 64, 0.6); // dmg taken from blast reduced
 		TF2Items_SetAttribute(item1, 1, 527, 1.0); // afterburn immunity
+	}
+
+	else if (
+		ItemIsEnabled("tomislav") &&
+		StrEqual(class, "tf_weapon_minigun") &&
+		(index == 424)
+	) {
+		item1 = TF2Items_CreateItem(0);
+		TF2Items_SetFlags(item1, (OVERRIDE_ATTRIBUTES|PRESERVE_ATTRIBUTES));
+		TF2Items_SetNumAttributes(item1, 2);
+		TF2Items_SetAttribute(item1, 0, 87, 0.60); // 40% minigun spinup time decreased; mult_minigun_spinup_time
+		TF2Items_SetAttribute(item1, 1, 106, 1.0); // 0% accuracy attribute; weapon spread bonus; mult_spread_scale
 	}
 
 	else if (


### PR DESCRIPTION
**The Tomislav**
- 40% faster spin up time
- No accuracy bonus
- Silent Killer: No barrel spin sound
- 20% slower firing speed

Existed for a year (June 28, 2011 - June 27, 2012). 

From initial impromptu playtesting with bots (and with the minigun rampup revert) by a Heavy main, it seems to have a different playstyle compared to the present version. Worth a shot in testing since nobody remembers this version now.

This can be disabled if you want to and if more discussion is needed.

Side note: this revert is 95% accurate, the other 5% are just cosmetic stuff like a higher pitch gun sound and a different deploy sound (that could be done with a gamebanana mod anyways).

Side note 2: This revert is functionally accurate as long as the minigun rampup revert is in effect.