### PR TITLE
(Revert) Historically Accurate Shortstop (Pre-Manniversary)

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -352,7 +352,7 @@ public void OnPluginStart() {
 	ItemDefine("Sandman", "sandman", "Reverted to pre-inferno, stuns players on hit again, 15 sec ball recharge time", CLASSFLAG_SCOUT);
 	ItemDefine("Scottish Resistance", "scottish", "Reverted to release, 0.4 arm time penalty (from 0.8), no fire rate bonus", CLASSFLAG_DEMOMAN);
 	ItemDefine("Short Circuit", "circuit", "Reverted to post-gunmettle, alt fire destroys projectiles, -cost +speed", CLASSFLAG_ENGINEER);
-	ItemDefine("Shortstop", "shortstop", "Reverted reload time to release version, with +40% push force", CLASSFLAG_SCOUT);
+	ItemDefine("Shortstop", "shortstop", "Reverted to pre-Manniversary, faster reload time, no push force penalty, shares pistol ammo; modern shove is kept", CLASSFLAG_SCOUT);
 	ItemDefine("Soda Popper", "sodapop", "Reverted to pre-Smissmas 2013, run to build hype and auto gain minicrits", CLASSFLAG_SCOUT);
 	ItemDefine("Solemn Vow", "solemn", "Reverted to pre-gunmettle, firing speed penalty removed", CLASSFLAG_MEDIC);
 	ItemDefine("Splendid Screen", "splendid", "Reverted to pre-toughbreak, 15% blast resist, no faster recharge, old shield mechanics, bash dmg at any range", CLASSFLAG_DEMOMAN);
@@ -842,7 +842,7 @@ public void OnGameFrame() {
 					}
 
 					{
-						// shortstop shove
+						// shortstop shove & primary ammo sharing with secondary pistol ammo
 
 						if (ItemIsEnabled("shortstop")) {
 							weapon = GetEntPropEnt(idx, Prop_Send, "m_hActiveWeapon");
@@ -850,10 +850,18 @@ public void OnGameFrame() {
 							if (weapon > 0) {
 								GetEntityClassname(weapon, class, sizeof(class));
 
+								// leftover code from Bakugo
 								if (StrEqual(class, "tf_weapon_handgun_scout_primary")) {
 									// disable secondary attack
 									// this is somewhat broken, can still shove by holding m2 when reload ends
 									// SetEntPropFloat(weapon, Prop_Send, "m_flNextSecondaryAttack", (GetGameTime() + 1.0));
+								}
+
+								// make shortstop use secondary pistol ammo type
+								int SCOUT_PISTOL_AMMO_TYPE = 2;
+
+								if (StrEqual(class, "tf_weapon_handgun_scout_primary")) {
+									SetEntProp(weapon, Prop_Send, "m_iPrimaryAmmoType", SCOUT_PISTOL_AMMO_TYPE);
 								}
 							}
 						}
@@ -2010,10 +2018,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 	) {
 		item1 = TF2Items_CreateItem(0);
 		TF2Items_SetFlags(item1, (OVERRIDE_ATTRIBUTES|PRESERVE_ATTRIBUTES));
-		TF2Items_SetNumAttributes(item1, 3);
+		TF2Items_SetNumAttributes(item1, 5);
 		TF2Items_SetAttribute(item1, 0, 241, 1.0); // reload time increased hidden
-		TF2Items_SetAttribute(item1, 1, 534, 1.4); // airblast vulnerability multiplier hidden
-		TF2Items_SetAttribute(item1, 2, 535, 1.4); // damage force increase hidden
+		TF2Items_SetAttribute(item1, 1, 534, 1.00); // airblast vulnerability multiplier hidden
+		TF2Items_SetAttribute(item1, 2, 535, 1.00); // damage force increase hidden
+		TF2Items_SetAttribute(item1, 3, 536, 1.00); // damage force increase text
+		TF2Items_SetAttribute(item1, 4, 76, 1.125); // 12.5% max primary ammo on wearer, reverts max ammo back to 36, required for ammo sharing to work
 	}
 
 	else if (


### PR DESCRIPTION
Note: The shove is still kept in because a. players like it and its really useless and b. it's more trouble than its worth

The current Shortstop in the plugin appears to use the reload speed of the pre-Manniversary Shortstop. 
Thus, to make the weapon revert more historically accurate, the push force penalty has been removed, and the ammo sharing mechanic with any of the Scout's pistols is re-implemented (which also increases the max ammo reserve of the Shortstop from 32 to 36).

> 
> **October 13, 2011 Patch (Manniversary Update & Sale)** 
> - [Undocumented] The Shortstop reload time has been slowed down by 50%.

Historically, the pre-Manniversary Shortstop had the following stats: 

**The Shortstop**
- No reload speed penalty
- No push force penalty
- Shares ammo with the Scout's Pistol

Historical reference:
https://wiki.teamfortress.com/w/index.php?title=Shortstop&oldid=754125

This has been tested on Windows.