### PR TITLE
(Fix) Prevent Spycicle from picking up ammo when melted

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -24,6 +24,20 @@
 				"windows" "\x55\x8B\xEC\x83\xEC\x18\x56\x8B\xF1\x8B\x0D\x2A\x2A\x2A\x2A" //  offset aMultPlayerAimi ; "mult_player_aiming_movespeed"
 				"linux"	  "@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
 			}
+
+			"CTFAmmoPack::PackTouch"
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\x83\xEC\x1C\x53\x8B\x5D\x08\x56"
+				"linux"   "@_ZN11CTFAmmoPack9PackTouchEP11CBaseEntity"
+			}
+			
+			"CTFPlayer::AddToSpyKnife"
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\x6A\x07"
+				"linux"   "@_ZN9CTFPlayer13AddToSpyKnifeEfb"
+			}			
 		}
 
 		"Offsets"
@@ -44,6 +58,18 @@
 			{
 				"linux" "245"
 				"windows" "244"
+			}
+
+			"CAmmoPack::MyTouch"
+			{
+				"windows" "229"
+				"linux"   "230"
+			}
+			
+			"CAmmoPack::GetPowerupSize"
+			{
+				"windows" "234"
+				"linux"   "237"
 			}
 		}
 
@@ -73,6 +99,21 @@
 				"return" "float"
 			}
 
+			"CAmmoPack::MyTouch"
+			{
+				"offset"   "CAmmoPack::MyTouch"
+				"hooktype" "entity"
+				"this"     "entity"
+				"return"   "bool"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type" "int"
+					}
+				}
+			}
+
 			"CTFPlayer::CanDisguise"
 			{
 				"signature" "CTFPlayer::CanDisguise"
@@ -95,6 +136,40 @@
 					}
 				}
 			}
+
+			"CTFAmmoPack::PackTouch"
+			{
+				"signature" "CTFAmmoPack::PackTouch"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "void"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type" "cbaseentity"
+					}
+				}
+			}
+
+			"CTFPlayer::AddToSpyKnife"
+			{
+				"signature" "CTFPlayer::AddToSpyKnife"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "bool"
+				"arguments"
+				{
+					"value"
+					{
+						"type" "float"
+					}
+					"force"
+					{
+						"type" "bool"
+					}
+				}
+			}			
 		}
 	}
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -359,7 +359,7 @@ public void OnPluginStart() {
 	ItemDefine("Soda Popper", "sodapop", "Reverted to pre-Smissmas 2013, run to build hype and auto gain minicrits", CLASSFLAG_SCOUT);
 	ItemDefine("Solemn Vow", "solemn", "Reverted to pre-gunmettle, firing speed penalty removed", CLASSFLAG_MEDIC);
 	ItemDefine("Splendid Screen", "splendid", "Reverted to pre-toughbreak, 15% blast resist, no faster recharge, old shield mechanics, bash dmg at any range", CLASSFLAG_DEMOMAN);
-	ItemDefine("Spy-cicle", "spycicle", "Reverted to pre-gunmettle, fire immunity for 2s, silent killer", CLASSFLAG_SPY);
+	ItemDefine("Spy-cicle", "spycicle", "Reverted to pre-gunmettle, fire immunity for 2s, silent killer, cannot regenerate from ammo sources", CLASSFLAG_SPY);
 	ItemDefine("Sticky Jumper", "stkjumper", "Reverted to Pyromania update, can have 8 stickybombs out at once again", CLASSFLAG_DEMOMAN);
 	ItemDefine("Sydney Sleeper", "sleeper", "Reverted to pre-2018, restored jarate explosion, no headshots", CLASSFLAG_SNIPER);
 	ItemDefine("Tide Turner", "turner", "Reverted to pre-toughbreak, can deal full crits, 25% blast and fire resist, crit after bash, no debuff removal", CLASSFLAG_DEMOMAN);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4301,7 +4301,11 @@ int abs(int x)
 
 MRESReturn DHookCallback_CTFPlayer_AddToSpyKnife(int entity, DHookReturn returnValue, DHookParam parameters)
 {
-    // Prevent ammo pick-up with the spycicle when cloak meter AND ammo are full.
-    returnValue.Value = false;
-    return MRES_Supercede;
+    if (ItemIsEnabled("spycicle"))
+    {
+        // Prevent ammo pick-up with the spycicle when cloak meter AND ammo are full.
+        returnValue.Value = false;
+        return MRES_Supercede;
+    }
+    return MRES_Ignored;
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -233,6 +233,9 @@ Handle dhook_CTFBaseRocket_GetRadius;
 Handle dhook_CTFPlayer_CanDisguise;
 Handle dhook_CTFPlayer_CalculateMaxSpeed;
 
+// Spycicle ammo pickup fix imported from NotnHeavy's plugin
+DHookSetup dhook_CTFPlayer_AddToSpyKnife;
+
 Item items[ITEMS_MAX];
 Player players[MAXPLAYERS+1];
 Entity entities[2048];
@@ -436,6 +439,7 @@ public void OnPluginStart() {
 		dhook_CTFBaseRocket_GetRadius = DHookCreateFromConf(conf, "CTFBaseRocket::GetRadius");
 		dhook_CTFPlayer_CanDisguise = DHookCreateFromConf(conf, "CTFPlayer::CanDisguise");
 		dhook_CTFPlayer_CalculateMaxSpeed = DHookCreateFromConf(conf, "CTFPlayer::TeamFortress_CalculateMaxSpeed");
+		dhook_CTFPlayer_AddToSpyKnife = DHookCreateFromConf(conf, "CTFPlayer::AddToSpyKnife");
 
 		delete conf;
 	}
@@ -555,10 +559,12 @@ public void OnPluginStart() {
 	if (dhook_CTFBaseRocket_GetRadius == null) SetFailState("Failed to create dhook_CTFBaseRocket_GetRadius");
 	if (dhook_CTFPlayer_CanDisguise == null) SetFailState("Failed to create dhook_CTFPlayer_CanDisguise");
 	if (dhook_CTFPlayer_CalculateMaxSpeed == null) SetFailState("Failed to create dhook_CTFPlayer_CalculateMaxSpeed");
-	
+	if (dhook_CTFPlayer_AddToSpyKnife == null) SetFailState("Failed to create dhook_CTFPlayer_AddToSpyKnife");
+
 	
 	DHookEnableDetour(dhook_CTFPlayer_CanDisguise, true, DHookCallback_CTFPlayer_CanDisguise);
 	DHookEnableDetour(dhook_CTFPlayer_CalculateMaxSpeed, true, DHookCallback_CTFPlayer_CalculateMaxSpeed);
+	DHookEnableDetour(dhook_CTFPlayer_AddToSpyKnife, false, DHookCallback_CTFPlayer_AddToSpyKnife);
 
 	for (idx = 1; idx <= MaxClients; idx++) {
 		if (IsClientConnected(idx)) OnClientConnected(idx);
@@ -4291,4 +4297,11 @@ int abs(int x)
 {
 	int mask = x >> 31;
 	return (x + mask) ^ mask;
+}
+
+MRESReturn DHookCallback_CTFPlayer_AddToSpyKnife(int entity, DHookReturn returnValue, DHookParam parameters)
+{
+    // Prevent ammo pick-up with the spycicle when cloak meter AND ammo are full.
+    returnValue.Value = false;
+    return MRES_Supercede;
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -570,12 +570,12 @@ public void OnPluginStart() {
 	if (dhook_CTFPlayer_CanDisguise == null) SetFailState("Failed to create dhook_CTFPlayer_CanDisguise");
 	if (dhook_CTFPlayer_CalculateMaxSpeed == null) SetFailState("Failed to create dhook_CTFPlayer_CalculateMaxSpeed");
 	if (dhook_CTFPlayer_AddToSpyKnife == null) SetFailState("Failed to create dhook_CTFPlayer_AddToSpyKnife");
-  if (dhook_CAmmoPack_MyTouch == null) SetFailState("Failed to create dhook_CAmmoPack_MyTouch");
+  	if (dhook_CAmmoPack_MyTouch == null) SetFailState("Failed to create dhook_CAmmoPack_MyTouch");
 	if (dhook_CTFAmmoPack_PackTouch == null) SetFailState("Failed to create dhook_CTFAmmoPack_PackTouch");
 
 	DHookEnableDetour(dhook_CTFPlayer_CanDisguise, true, DHookCallback_CTFPlayer_CanDisguise);
 	DHookEnableDetour(dhook_CTFPlayer_CalculateMaxSpeed, true, DHookCallback_CTFPlayer_CalculateMaxSpeed);
-  DHookEnableDetour(dhook_CTFPlayer_AddToSpyKnife, false, DHookCallback_CTFPlayer_AddToSpyKnife);
+  	DHookEnableDetour(dhook_CTFPlayer_AddToSpyKnife, false, DHookCallback_CTFPlayer_AddToSpyKnife);
 	DHookEnableDetour(dhook_CTFAmmoPack_PackTouch, false, DHookCallback_CTFAmmoPack_PackTouch);
 
 	for (idx = 1; idx <= MaxClients; idx++) {


### PR DESCRIPTION
Using code and gamedata from NotnHeavy's plugin (gamedata also contains persian persuader gamedata)
Added new info for Spycicle ItemDefine about no regeneration from ammo sources

Tested on Windows
~~Un~~tested on Linux.