### PR TITLE
(fix) persian persuader dropped ammo pickup sound

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4371,7 +4371,10 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
 
             // Set health.
             SetEntityHealth(client, intMin(health + 20, health_max));
-	    EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // if ammo_pickup sound doesn't play, this should make it play
+	    // If you're wondering why EmitSoundToAll below is repeated in a different channel, 
+	    // it's so it sounds louder to be like the actual in-game sound and because I can't increase the volume beyond 1.0 for some reason.
+	    EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // If ammo_pickup sound doesn't play, this should make it play.
+	    EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_BODY, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // and I am forced to do this to make it louder. I tried. Why?
             RemoveEntity(entity);
         }
         return MRES_Supercede;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4371,6 +4371,7 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
 
             // Set health.
             SetEntityHealth(client, intMin(health + 20, health_max));
+	    EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // if ammo_pickup sound doesn't play, this should make it play
             RemoveEntity(entity);
         }
         return MRES_Supercede;


### PR DESCRIPTION
edit: huutti confirmed that the dropped ammo pickup sound doesn't play on linux

untested on windows (because pickups don't work on windows) and linux

i tested the sound on windows by replacing gunpick2.wav in DHookCallback_CAmmoPack_MyTouch with ammo_pickup.wav, so it hasn't been tested to see if it works in DHookCallback_CTFAmmoPack_PackTouch.

dropped ammo pickup sound from dead players uses the default half-life 2 ammo pick-up sound
sounds/items/ammo_pickup.wav

if ever the sound doesn't play, then this should make the sound play for sure