### PR TITLE
(Fix) Persian Persuader Afterburn and Bleed Removal on Ammo Heal

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4399,6 +4399,13 @@ MRESReturn DHookCallback_CAmmoPack_MyTouch(int entity, DHookReturn returnValue, 
             SetEventInt(event, "entindex", client);
             FireEvent(event);
 
+			// remove afterburn and bleed debuffs on heal
+			if (TF2_IsPlayerInCondition(client, TFCond_OnFire) || TF2_IsPlayerInCondition(client, TFCond_Bleeding)) 
+			{
+				TF2_RemoveCondition(client, TFCond_OnFire);
+				TF2_RemoveCondition(client, TFCond_Bleeding);
+			}
+
             // Set health.
             SetEntityHealth(client, intMin(health + heal, health_max));
             EmitSoundToAll("items/gunpickup2.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL);
@@ -4425,13 +4432,20 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
             SetEventInt(event, "entindex", client);
             FireEvent(event);
 
+			// remove afterburn and bleed debuffs on heal
+			if (TF2_IsPlayerInCondition(client, TFCond_OnFire) || TF2_IsPlayerInCondition(client, TFCond_Bleeding)) 
+			{
+				TF2_RemoveCondition(client, TFCond_OnFire);
+				TF2_RemoveCondition(client, TFCond_Bleeding);
+			}
+
             // Set health.
             SetEntityHealth(client, intMin(health + 20, health_max));
-	    // If you're wondering why EmitSoundToAll below is repeated in a different channel, 
-	    // it's so it sounds louder to be like the actual in-game sound and because I can't increase the volume beyond 1.0 for some reason.
-	    EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // If ammo_pickup sound doesn't play, this should make it play.
-	    EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_BODY, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // and I am forced to do this to make it louder. I tried. Why?
-            RemoveEntity(entity);
+			// If you're wondering why EmitSoundToAll below is repeated in a different channel, 
+			// it's so it sounds louder to be like the actual in-game sound and because I can't increase the volume beyond 1.0 for some reason.
+			EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // If ammo_pickup sound doesn't play, this should make it play.
+			EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_BODY, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // and I am forced to do this to make it louder. I tried. Why?
+			RemoveEntity(entity);
         }
         return MRES_Supercede;
     }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4382,22 +4382,22 @@ float PersuaderPackRatios[] =
 MRESReturn DHookCallback_CAmmoPack_MyTouch(int entity, DHookReturn returnValue, DHookParam parameters)
 {
 	int client = GetEntityFromAddress(parameters.Get(1));
-    if (ItemIsEnabled("persuader") && player_weapons[client][Wep_PersianPersuader])
-    {
+	if (ItemIsEnabled("persuader") && player_weapons[client][Wep_PersianPersuader])
+	{
 		// Health pickup with the Persian Persuader.
-        returnValue.Value = false;
+		returnValue.Value = false;
 		int health = GetClientHealth(client);
-        int health_max = SDKCall(sdkcall_GetMaxHealth, client);
-        if (health < health_max)
-        {
-            // Get amount to heal.
-            int heal = RoundFloat(40 * PersuaderPackRatios[SDKCall(sdkcall_CAmmoPack_GetPowerupSize, entity)]);
-
-            // Show that the player got healed.
-            Handle event = CreateEvent("player_healonhit", true);
-            SetEventInt(event, "amount", heal);
-            SetEventInt(event, "entindex", client);
-            FireEvent(event);
+		int health_max = SDKCall(sdkcall_GetMaxHealth, client);
+		if (health < health_max)
+        	{
+			// Get amount to heal.
+	        	int heal = RoundFloat(40 * PersuaderPackRatios[SDKCall(sdkcall_CAmmoPack_GetPowerupSize, entity)]);
+	
+			// Show that the player got healed.
+			Handle event = CreateEvent("player_healonhit", true);
+			SetEventInt(event, "amount", heal);
+			SetEventInt(event, "entindex", client);
+			FireEvent(event);
 
 			// remove afterburn and bleed debuffs on heal
 			if (TF2_IsPlayerInCondition(client, TFCond_OnFire) || TF2_IsPlayerInCondition(client, TFCond_Bleeding)) 
@@ -4406,31 +4406,31 @@ MRESReturn DHookCallback_CAmmoPack_MyTouch(int entity, DHookReturn returnValue, 
 				TF2_RemoveCondition(client, TFCond_Bleeding);
 			}
 
-            // Set health.
-            SetEntityHealth(client, intMin(health + heal, health_max));
-            EmitSoundToAll("items/gunpickup2.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL);
-            returnValue.Value = true;
-        }
-        return MRES_Supercede;
-    }
-    return MRES_Ignored;
+			// Set health.
+			SetEntityHealth(client, intMin(health + heal, health_max));
+			EmitSoundToAll("items/gunpickup2.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL);
+			returnValue.Value = true;
+		}
+		return MRES_Supercede;
+	}
+	return MRES_Ignored;
 }
 
 MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters)
 {
 	int client = parameters.Get(1);
-    if (ItemIsEnabled("persuader") && client > 0 && client <= MaxClients && player_weapons[client][Wep_PersianPersuader])
-    {
+	if (ItemIsEnabled("persuader") && client > 0 && client <= MaxClients && player_weapons[client][Wep_PersianPersuader])
+	{
 		// Health pickup with the Persian Persuader from dropped ammo packs.
-        int health = GetClientHealth(client);
+		int health = GetClientHealth(client);
 		int health_max = SDKCall(sdkcall_GetMaxHealth, client);
-        if (health < health_max)
-        {
-            // Show that the player got healed.
-            Handle event = CreateEvent("player_healonhit", true);
-            SetEventInt(event, "amount", 20);
-            SetEventInt(event, "entindex", client);
-            FireEvent(event);
+		if (health < health_max)
+		{
+			// Show that the player got healed.
+			Handle event = CreateEvent("player_healonhit", true);
+			SetEventInt(event, "amount", 20);
+			SetEventInt(event, "entindex", client);
+			FireEvent(event);
 
 			// remove afterburn and bleed debuffs on heal
 			if (TF2_IsPlayerInCondition(client, TFCond_OnFire) || TF2_IsPlayerInCondition(client, TFCond_Bleeding)) 
@@ -4439,17 +4439,17 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
 				TF2_RemoveCondition(client, TFCond_Bleeding);
 			}
 
-            // Set health.
-            SetEntityHealth(client, intMin(health + 20, health_max));
+			// Set health.
+			SetEntityHealth(client, intMin(health + 20, health_max));
 			// If you're wondering why EmitSoundToAll below is repeated in a different channel, 
 			// it's so it sounds louder to be like the actual in-game sound and because I can't increase the volume beyond 1.0 for some reason.
 			EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // If ammo_pickup sound doesn't play, this should make it play.
 			EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_BODY, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // and I am forced to do this to make it louder. I tried. Why?
 			RemoveEntity(entity);
-        }
-        return MRES_Supercede;
-    }
-    return MRES_Ignored;
+		}
+		return MRES_Supercede;
+	}
+	return MRES_Ignored;
 }
 
 #if defined VERDIUS_PATCHES


### PR DESCRIPTION
### Summary of changes
Persian Persuader is supposed to remove afterburn and bleed when healing from ammo packs (see https://youtu.be/DxAvFdL-tFc). This just removes those conditions when that happens.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Tested on Windows. Only tested with map ammo packs

### Other Info
~~Why are the tabs and spacing weird and off in Github? Does anyone know how to fix this? I don't know how~~
