### PR TITLE
remove sm_reverts__extras & commented lines for menu_pick

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -247,7 +247,6 @@ Item items[ITEMS_MAX];
 Player players[MAXPLAYERS+1];
 Entity entities[2048];
 int frame;
-Handle hudsync;
 Menu menu_main;
 int rocket_create_entity;
 int rocket_create_frame;
@@ -397,8 +396,6 @@ public void OnPluginStart() {
 	ItemFinalize();
 
 	AutoExecConfig(false, "reverts", "sourcemod");
-
-	hudsync = CreateHudSynchronizer();
 
 	cvar_ref_tf_airblast_cray = FindConVar("tf_airblast_cray");
 	cvar_ref_tf_bison_tick_time = FindConVar("tf_bison_tick_time");


### PR DESCRIPTION
### Summary of changes
Removes sm_reverts__extras & commented lines for menu_pick

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
Minor refactor, shouldn't affect anything

### Other Info
N/A
