### PR TITLE
Add Git commit hash to version number in reverts when compiling via CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
           mv include/*.inc ../../../../scripting/include
           mv nativevotes ../../../../scripting
 
+      - name: Get current Git commit hash
+        run: echo "GIT_COMMIT=-$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
+
+      - name: Preprocess reverts.sp
+        run: ./reverts-git-commit.sh
+
       - name: Build plugins
         run: |
           cd scripting
@@ -49,4 +55,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: artifact
-          name: package-${{matrix.sm-target}}
+          name: package-${{ matrix.sm-target }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ gamedata/*
 !.github/workflows/
 .github/workflows/*
 !.github/workflows/build.yml
+
+!reverts-git-commit.sh

--- a/reverts-git-commit.sh
+++ b/reverts-git-commit.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sed -i "s/\/\/#define GIT_COMMIT/#define GIT_COMMIT/" scripting/reverts.sp
+sed -i "s/%GIT_COMMIT%/$GIT_COMMIT/" scripting/reverts.sp

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -67,13 +67,23 @@
 #define PLUGIN_VERSION PLUGIN_VERSION_NUM
 #endif
 
+//#define GIT_COMMIT
+
+#if defined GIT_COMMIT
+#define PLUGIN_VERSION_GIT PLUGIN_VERSION ... "%GIT_COMMIT%"
+#endif
+
 #define PLUGIN_URL "https://steamcommunity.com/profiles/76561198020610103"
 
 public Plugin myinfo = {
 	name = PLUGIN_NAME,
 	description = PLUGIN_DESC,
 	author = PLUGIN_AUTHOR,
+#if defined GIT_COMMIT
+	version = PLUGIN_VERSION_GIT,
+#else
 	version = PLUGIN_VERSION,
+#endif
 	url = PLUGIN_URL
 };
 


### PR DESCRIPTION
### Summary of changes
Add Git commit hash to version number in reverts when compiling via CI pipeline

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Installed the plugin and ran `sm plugins list`

### Other Info
This solution is quite hacky, there doesn't seem to be a way in SourcePawn to concatenate 2 defines and `compile.sh` doesn't recognize defines passed in via the command lines, so I had to preprocess the file in a shell script.
