### PR TITLE
fix plugin version cvar when GIT_COMMIT is defined

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -308,7 +308,11 @@ public void OnPluginStart() {
 	
 	CCheckTrie();
 
+#if defined GIT_COMMIT
+	CreateConVar("sm_reverts__version", PLUGIN_VERSION_GIT, (PLUGIN_NAME ... " - Version"), (FCVAR_NOTIFY|FCVAR_DONTRECORD));
+#else
 	CreateConVar("sm_reverts__version", PLUGIN_VERSION, (PLUGIN_NAME ... " - Version"), (FCVAR_NOTIFY|FCVAR_DONTRECORD));
+#endif
 
 	cvar_enable = CreateConVar("sm_reverts__enable", "1", (PLUGIN_NAME ... " - Enable plugin"), _, true, 0.0, true, 1.0);
 	cvar_extras = CreateConVar("sm_reverts__extras", "0", (PLUGIN_NAME ... " - Enable some fun extra features"), _, true, 0.0, true, 1.0);


### PR DESCRIPTION
### Summary of changes
Follow up patch to yesterday's git commit hash in version number patch. Oversight on my part. 

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
Minor change

### Other Info
N/A
