### PR TITLE
Credited NotnHeavy and reverted so theres a 1 second disable on wrangled sentry owners death.

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -630,12 +630,6 @@ public void OnPluginStart() {
 		if (IsClientConnected(idx)) OnClientConnected(idx);
 		if (IsClientInGame(idx)) OnClientPutInServer(idx);
 	}
-
-	PrintToServer("=================================");
-	PrintToServer("=================================");
-	PrintToServer("PRINT TO SERVER?!?!?!?!");
-	PrintToServer("=================================");
-	PrintToServer("=================================");
 }
 
 public void JumperFlagRunCvarChange(Handle convar, const char[] oldValue, const char[] newValue) {
@@ -2536,7 +2530,6 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 							ItemIsEnabled("ambassador") &&
 							StrEqual(class, "tf_weapon_revolver")
 						) {
-							PrintToServer("========== Someone was killed with ambassador ==============");
 							SetEventInt(event, "customkill", TF_CUSTOM_HEADSHOT);
 
 							return Plugin_Changed;
@@ -4203,7 +4196,6 @@ public bool AddProgressOnAchievement(int playerID, int achievementID, int Amount
 
 int FindSentryGunOwnedByClient(int client)
 {
-	PrintToServer("FindSentryGunOwnedByClient: client is %d",client);
     if (!IsClientInGame(client) || GetClientTeam(client) < 2)
         return -1;
 
@@ -4211,7 +4203,6 @@ int FindSentryGunOwnedByClient(int client)
     while ((ent = FindEntityByClassname(ent, "obj_sentrygun")) != -1)
     {
         int owner = GetEntPropEnt(ent,Prop_Send,"m_hBuilder");
-        PrintToServer("FindSentryGunOwnedByClient: owner is %d",owner);
         if (owner == client)
             return ent;
     }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -20,7 +20,7 @@
 #undef VERDIUS_PATCHES
 #endif
 
-#define WIN32
+//#define WIN32
 /*
  ^ ^ ^ ^ ^ ^ ^ ^ ^
 	Additionally, you will need to select your compile OS.

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -20,7 +20,7 @@
 #undef VERDIUS_PATCHES
 #endif
 
-//#define WIN32
+#define WIN32
 /*
  ^ ^ ^ ^ ^ ^ ^ ^ ^
 	Additionally, you will need to select your compile OS.
@@ -2432,12 +2432,12 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 
 #if defined VERDIUS_PATCHES
 		// Just to ensure that if attacker is missing for some reason, that we still check the victim.
+		// Also check that wrangler revert is enabled.
 		if (
 			client > 0 &&
 			client <= MaxClients &&
-			IsClientInGame(client)
+			IsClientInGame(client) && ItemIsEnabled("wrangler")
 		) {
-
 			// 1 second sentry disable if wrangler shield active && engineer dies.
 			// should not effect the normal 3 second disable on engineer weapon switch etc.
 			if (TF2_GetPlayerClass(client) == TFClass_Engineer) {
@@ -2453,8 +2453,8 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						// Offset for Linux (0xB50)
 						StoreToAddress(sentryBaseAddr + view_as<Address>(0xB50), GetGameTime() + 1.0, NumberType_Int32);
 #else
-						// Offset for Windows (0x2CE)
-						StoreToAddress(sentryBaseAddr + view_as<Address>(0x2CE), GetGameTime() + 1.0, NumberType_Int32);
+						// Offset for Windows (0xB38) (Do not trust the ghidra decompiler for windows when looking for the offset, check assembly view instead after you click on the line that sets the member.)
+						StoreToAddress(sentryBaseAddr + view_as<Address>(0xB38), GetGameTime() + 1.0, NumberType_Int32);
 #endif
 	
 						isControlled = 0; // Make sure isControlled is set to 0 or org source code


### PR DESCRIPTION
### Summary of changes
Adds credits to NotnHeavy.
Adds new code to player_death section:
Uses StoreToAddress to offset from base address of a sentry entity to
reach m_flShieldFadeTime.

### Testing Attestation
- [x] - This change has been tested on Linux (Tested Twice now)
- [x] - This change has been tested on Windows
- [ ] (optional but recommended) - Others should test again with the recent changes and time how long it takes for the sentry to return to active on both Linux and Windows.
### Description of testing
Compiled and launched a Linux Server of TF2. Lol...

### Other Info
Needs testing on windows before it can be merged into castaway.tf weapon revert master.
