### PR TITLE
add cvar to keep dropped weapons on the ground

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -31,14 +31,19 @@
 				"windows" "\x55\x8B\xEC\x83\xEC\x24\x56\x8B\x75\x2A\x57\x8B\xF9\x8B\x46"
 				"linux"   "@_ZN11CTFAmmoPack9PackTouchEP11CBaseEntity"
 			}
-			
+
 			"CTFPlayer::AddToSpyKnife"
 			{
 				"library" "server"
 				"windows" "\x55\x8B\xEC\x6A\x07"
 				"linux"   "@_ZN9CTFPlayer13AddToSpyKnifeEfb"
-			}			
+			}
 
+			"CTFPlayer::PickupWeaponFromOther"
+			{
+				"library" "server"
+				"linux"   "@_ZN9CTFPlayer21PickupWeaponFromOtherEP16CTFDroppedWeapon"
+			}
 		}
 
 		"Offsets"
@@ -170,7 +175,22 @@
 						"type" "bool"
 					}
 				}
-			}			
+			}
+
+			"CTFPlayer::PickupWeaponFromOther"
+			{
+				"signature" "CTFPlayer::PickupWeaponFromOther"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "bool"
+				"arguments"
+				{
+					"pDroppedWeapon"
+					{
+						"type" "cbaseentity"
+					}
+				}
+			}		
 		}
 	}
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -194,6 +194,7 @@ ConVar cvar_enable;
 ConVar cvar_extras;
 ConVar cvar_jumper_flag_run;
 ConVar cvar_old_falldmg_sfx;
+ConVar cvar_dropped_weapon_enable;
 ConVar cvar_ref_tf_airblast_cray;
 ConVar cvar_ref_tf_bison_tick_time;
 ConVar cvar_ref_tf_dropped_weapon_lifetime;
@@ -256,6 +257,7 @@ Handle dhook_CTFWeaponBase_SecondaryAttack;
 Handle dhook_CTFBaseRocket_GetRadius;
 Handle dhook_CTFPlayer_CanDisguise;
 Handle dhook_CTFPlayer_CalculateMaxSpeed;
+Handle dhook_CTFPlayer_PickupWeaponFromOther;
 Handle dhook_CAmmoPack_MyTouch;
 Handle dhook_CTFAmmoPack_PackTouch;
 
@@ -318,6 +320,7 @@ public void OnPluginStart() {
 	cvar_extras = CreateConVar("sm_reverts__extras", "0", (PLUGIN_NAME ... " - Enable some fun extra features"), _, true, 0.0, true, 1.0);
 	cvar_jumper_flag_run = CreateConVar("sm_reverts__jumper_flag_run", "0", (PLUGIN_NAME ... " - Enable intel pick-up for jumper weapons"), _, true, 0.0, true, 1.0);
 	cvar_old_falldmg_sfx = CreateConVar("sm_reverts__old_falldmg_sfx", "1", (PLUGIN_NAME ... " - Enable old (pre-inferno) fall damage sound (old bone crunch, no hurt voicelines)"), _, true, 0.0, true, 1.0);
+	cvar_dropped_weapon_enable = CreateConVar("sm_reverts__enable_dropped_weapon", "0", (PLUGIN_NAME ... " - Keep dropped weapons but disallow picking them up"), _, true, 0.0, true, 1.0);
 
 	cvar_jumper_flag_run.AddChangeHook(JumperFlagRunCvarChange);
 
@@ -485,6 +488,7 @@ public void OnPluginStart() {
 		dhook_CTFPlayer_CanDisguise = DHookCreateFromConf(conf, "CTFPlayer::CanDisguise");
 		dhook_CTFPlayer_CalculateMaxSpeed = DHookCreateFromConf(conf, "CTFPlayer::TeamFortress_CalculateMaxSpeed");
 		dhook_CTFPlayer_AddToSpyKnife = DHookCreateFromConf(conf, "CTFPlayer::AddToSpyKnife");
+		dhook_CTFPlayer_PickupWeaponFromOther = DHookCreateFromConf(conf, "CTFPlayer::PickupWeaponFromOther");
 		dhook_CAmmoPack_MyTouch = DHookCreateFromConf(conf, "CAmmoPack::MyTouch");
 		dhook_CTFAmmoPack_PackTouch =  DHookCreateFromConf(conf, "CTFAmmoPack::PackTouch");
 
@@ -618,12 +622,14 @@ public void OnPluginStart() {
 	if (dhook_CTFPlayer_CanDisguise == null) SetFailState("Failed to create dhook_CTFPlayer_CanDisguise");
 	if (dhook_CTFPlayer_CalculateMaxSpeed == null) SetFailState("Failed to create dhook_CTFPlayer_CalculateMaxSpeed");
 	if (dhook_CTFPlayer_AddToSpyKnife == null) SetFailState("Failed to create dhook_CTFPlayer_AddToSpyKnife");
+	if (dhook_CTFPlayer_PickupWeaponFromOther == null) SetFailState("Failed to create dhook_CTFPlayer_PickupWeaponFromOther");
   	if (dhook_CAmmoPack_MyTouch == null) SetFailState("Failed to create dhook_CAmmoPack_MyTouch");
 	if (dhook_CTFAmmoPack_PackTouch == null) SetFailState("Failed to create dhook_CTFAmmoPack_PackTouch");
 
 	DHookEnableDetour(dhook_CTFPlayer_CanDisguise, true, DHookCallback_CTFPlayer_CanDisguise);
 	DHookEnableDetour(dhook_CTFPlayer_CalculateMaxSpeed, true, DHookCallback_CTFPlayer_CalculateMaxSpeed);
   	DHookEnableDetour(dhook_CTFPlayer_AddToSpyKnife, false, DHookCallback_CTFPlayer_AddToSpyKnife);
+	DHookEnableDetour(dhook_CTFPlayer_PickupWeaponFromOther, false, DHookCallback_CTFPlayer_PickupWeaponFromOther);
 	DHookEnableDetour(dhook_CTFAmmoPack_PackTouch, false, DHookCallback_CTFAmmoPack_PackTouch);
 
 	for (idx = 1; idx <= MaxClients; idx++) {
@@ -1370,7 +1376,7 @@ public void OnGameFrame() {
 			// set all the convars needed
 
 			// weapon pickups are disabled to ensure attribute consistency
-			SetConVarMaybe(cvar_ref_tf_dropped_weapon_lifetime, "0", cvar_enable.BoolValue);
+			SetConVarMaybe(cvar_ref_tf_dropped_weapon_lifetime, "0", !cvar_dropped_weapon_enable.BoolValue);
 
 			// these cvars are changed just-in-time, reset them
 			ResetConVar(cvar_ref_tf_airblast_cray);
@@ -4505,6 +4511,14 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
 			EmitSoundToAll("items/ammo_pickup.wav", entity, SNDCHAN_BODY, SNDLEVEL_NORMAL, SND_CHANGEPITCH | SND_CHANGEVOL); // and I am forced to do this to make it louder. I tried. Why?
 			RemoveEntity(entity);
 		}
+		return MRES_Supercede;
+	}
+	return MRES_Ignored;
+}
+
+MRESReturn DHookCallback_CTFPlayer_PickupWeaponFromOther(int entity, DHookReturn returnValue, DHookParam parameters) {
+	if (cvar_dropped_weapon_enable.BoolValue) {
+		returnValue.Value = false;
 		return MRES_Supercede;
 	}
 	return MRES_Ignored;


### PR DESCRIPTION
### Summary of changes
Adds an option to keep dropped weapons, but disallow picking them up.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Boot up a server with bots and tried picking up weapons with the option enabled

### Other Info
Needs gamedata for Windows