### PR TITLE
(Changelog) disabled darwin's and tomislav reverts, update some item descriptions

### DIFF
--- a/RevertsChangelog.md
+++ b/RevertsChangelog.md
@@ -2,12 +2,15 @@
 
 [Go back to Castaway.tf Home](https://castaway.tf)
 
+### May 31, 2025
+- **Disabled the Darwin's Danger Shield and Tomislav reverts. The server now uses the modern versions of these items.**
+
 ### May 25, 2025
 - **Fixed reverted Persian Persuader not removing afterburn and bleed when picking up ammo packs as health, and increased pickup volume for dropped ammo packs.**
 - **Reverted the Buffalo Steak Sandvich to pre-Meet your Match**
   - *The Buffalo Steak Sandvich*
     - +10% damage vulnerability while active
-    - +35% fasater move speed while active
+    - +35% faster move speed while active
     - Effect lasts 16 seconds.
 
 ### May 24, 2025

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -443,8 +443,8 @@ public void OnPluginStart() {
 	ItemDefine("Panic Attack", "panic", "Reverted to pre-inferno, hold fire to load, let go to release, fire faster with bigger spread on lower health", CLASSFLAG_SOLDIER | CLASSFLAG_PYRO | CLASSFLAG_HEAVY | CLASSFLAG_ENGINEER, Wep_PanicAttack);
 	ItemDefine("Persian Persuader", "persuader", "Reverted to pre-toughbreak, picks up ammo as health, +100% charge recharge rate, no max ammo penalty", CLASSFLAG_DEMOMAN, Wep_Persian);
 	ItemDefine("Pomson 6000", "pomson", "Increased hitbox size (same as Bison), passes through team, no uber & cloak drain fall-off at any range", CLASSFLAG_ENGINEER, Wep_Pomson);
-	ItemDefine("Powerjack", "powerjack", "Reverted to pre-gunmettle, +75 HP on kill with overheal, +15% move speed & 20% dmg vuln while active", CLASSFLAG_PYRO, Wep_Powerjack);
-	ItemDefine("Pretty Boy's Pocket Pistol", "pocket", "Reverted to release, +15 health, no fall damage, slower firing speed, increased fire vuln", CLASSFLAG_SCOUT, Wep_PocketPistol);
+	ItemDefine("Powerjack", "powerjack", "Reverted to pre-gunmettle, kills restore 75 health with overheal", CLASSFLAG_PYRO, Wep_Powerjack);
+	ItemDefine("Pretty Boy's Pocket Pistol", "pocket", "Reverted to release, +15 max health, fall damage immunity, 25% slower fire rate, 50% fire vuln", CLASSFLAG_SCOUT, Wep_PocketPistol);
 #if defined VERDIUS_PATCHES
 	ItemDefine("Quick-Fix", "quickfix", "Reverted to pre-toughbreak, +25% uber build rate, can capture objectives when ubered", CLASSFLAG_MEDIC, Wep_QuickFix);
 #else


### PR DESCRIPTION
### Summary of changes
add when darwin's and tomislav reverts were disabled to changelog
updated item description for powerjack and pocket pistol

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
description changes
