### PR TITLE
add a cvar to disable loadout change reverts info by default + use native methods for cookie operations

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4291,7 +4291,7 @@ void ToggleLoadoutInfo(int client) {
 		if (config_value) {
 			ReplyToCommand(client, "Enabled loadout change revert info. They will be shown the next time you change loadouts.");
 		} else {
-			ReplyToCommand(client, "Disabled loadout change revert info. Enable them again by revisiting this menu.");
+			ReplyToCommand(client, "Disabled loadout change revert info. Enable them again by typing !revertsinfo or opening the reverts menu.");
 		}
 		g_hClientMessageCookie.SetInt(client, config_value ? 0 : 1);
 	}


### PR DESCRIPTION
### Summary of changes
Adds a cvar to disable loadout change reverts message by default and refactors cookie operations to use the native `GetInt` and `SetInt` methods

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Booted up a server of TF2...

### Other Info
N/A
