### PR TITLE
PR: Revert Disciplinary Action further to 4 seconds (both ally and soldier).

### DIFF
--- a/gamedata/verdiusarcana_reverts.txt
+++ b/gamedata/verdiusarcana_reverts.txt
@@ -117,17 +117,17 @@
 				// ╚══════════════════════════════════════════════╝
 
 				// ================================================
-				//  Disciplinary Action speed buff to allies 
-				//  for 3 seconds instead of 2 seconds.
+				//  Disciplinary Action speed buff
+				//  changed to 4 seconds (both ally and soldier).
 
-				"CTFWeaponBaseMelee::OnSwingHit_2fTO3fOnAllySpeedBuff"
+				"CTFWeaponBaseMelee::OnSwingHit_2f_To_4f_OnAllySpeedBuff_DisciplinaryAction"
 				{
 					"signature" "CTFWeaponBaseMelee::OnSwingHit"
 					"linux"
 					{
 						"offset"	"941"
 						"verify"	"\x68\x00\x00\x00\x40" // Verify that offset pushes 2.0f
-						"patch"	"\x68\x00\x00\x40\x40" // Change it to push 3.0f
+						"patch"	"\x68\x00\x00\x80\x40" // Change it to push 4.0f
 					}
 					// Windows compiler turned it into something that points at a address instead
 					// of directly pushing the float value, so we prepare the windows version of the patch for
@@ -135,6 +135,26 @@
 					"windows"
 					{
 						"offset"	"1049"
+						"verify"	"\xD9\x05\x2A\x2A\x2A\x2A" // Verify that FLD instruction is there, address bytes MUST be wildcarded.
+						"patch"	"\xD9\x05\x00\x00\x00\x00" // Set the address part to 4 "00", will change after patch enable to point to our address
+					}
+				}
+
+				"CTFWeaponBaseMelee::OnSwingHit_3.6f_To_4f_OnSoldierSpeedBuff_DisciplinaryAction"
+				{
+					"signature" "CTFWeaponBaseMelee::OnSwingHit"
+					"linux"
+					{
+						"offset"	"971"
+						"verify"	"\x68\x66\x66\x66\x40" // Verify that offset pushes 3.6f
+						"patch"	"\x68\x00\x00\x80\x40" // Change it to push 4.0f
+					}
+					// Windows compiler turned it into something that points at a address instead
+					// of directly pushing the float value, so we prepare the windows version of the patch for
+					// a Address Of natives.
+					"windows"
+					{
+						"offset"	"1074"
 						"verify"	"\xD9\x05\x2A\x2A\x2A\x2A" // Verify that FLD instruction is there, address bytes MUST be wildcarded.
 						"patch"	"\xD9\x05\x00\x00\x00\x00" // Set the address part to 4 "00", will change after patch enable to point to our address
 					}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -575,7 +575,7 @@ public void OnPluginStart() {
 			"CTFWeaponBaseMelee::OnSwingHit_2f_To_4f_OnAllySpeedBuff_DisciplinaryAction");
 		Verdius_RevertDisciplinaryAction_Soldier =
 			MemoryPatch.CreateFromConf(conf,
-			"CTFWeaponBaseMelee::OnSwingHit_3.6f_To_4f_OnSoldierSpeedBuff_DisciplinaryActio");
+			"CTFWeaponBaseMelee::OnSwingHit_3.6f_To_4f_OnSoldierSpeedBuff_DisciplinaryAction");
 #if defined WIN32
 		// If on Windows, perform the Address of Natives so we can patch in the address for the Discilpinary Action Ally Speedbuff.
 		AddressOf_g_flNewDisciplinaryActionSpeedBuffTimer = GetAddressOfCell(g_flNewDisciplinaryActionSpeedBuffTimer);
@@ -643,7 +643,8 @@ public void OnPluginStart() {
 		DHookEnableDetour(dHooks_CTFProjectile_Arrow_BuildingHealingArrow, true, PostHealingBoltImpact);
 
 		if (sdkcall_AwardAchievement == null) SetFailState("Failed to create sdkcall_AwardAchievement");
-		if (!ValidateAndNullCheck(Verdius_RevertDisciplinaryAction)) SetFailState("Failed to create Verdius_RevertDisciplinaryAction");
+		if (!ValidateAndNullCheck(Verdius_RevertDisciplinaryAction_Ally)) SetFailState("Failed to create Verdius_RevertDisciplinaryAction_Ally");
+		if (!ValidateAndNullCheck(Verdius_RevertDisciplinaryAction_Soldier)) SetFailState("Failed to create Verdius_RevertDisciplinaryAction_Soldier");
 
 		// Because we use only one MemoryPatch for Windows, we need to make sure we only try to Validate and Nullcheck one MemoryPatch.
 #if defined WIN32
@@ -787,7 +788,8 @@ void VerdiusTogglePatches(bool enable, int wep_enum) {
 				Verdius_RevertDisciplinaryAction_Soldier.Enable();
 #endif
 			} else {
-				Verdius_RevertDisciplinaryAction.Disable();
+				Verdius_RevertDisciplinaryAction_Ally.Disable();
+				Verdius_RevertDisciplinaryAction_Soldier.Disable();
 			}
 		}
 		case Wep_DragonFury: {


### PR DESCRIPTION
### Summary of changes
Changes speedbuff timer for Disciplinary Action to 4 seconds
for both Ally and Soldier, based on this request:
https://steamcommunity.com/groups/castawaytf/discussions/0/591756872987516258/?ctp=38#c601906364345790125

Before merging, check and verify that 4 seconds actually was a thing (I know protons does some good work downloading older depos to check older behavior, maybe he can do it to verify?) + check if this is desired by more than just one person.

Made this pull request in advance and to allow testing.

### Testing Attestation
- [x] - Linux tested 
- [ ] - Windows tested
- [ ] - Linux tested with someone else to check timing on ally
- [ ] - Windows tested with someone else to check timing on ally

### Description of testing
The best is to also time with someone else to check that ally gets 4 seconds too. Got 4 seconds on Linux for soldier using the whip on a stationary bot medic.
