### PR TITLE
Add support for revert variants, with pre-MyM Soda Popper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ sm_reverts__item_sodapop 2/1
 
 To get the name to use, open up the reverts.sp file and find the `ItemDefine` block near the top inside of OnPluginStart, and use the second value in the params.
 
-By default, all reverts are on with value 1.
+By default, all reverts are on with value of 1.
 
 ## Additional Credits
 Some or all of these plugins have been modified in some way, sometimes in major ways. I do not claim credit for these plugins and all credit goes to their original creators.

--- a/README.md
+++ b/README.md
@@ -63,15 +63,21 @@ If you want to disable a specific weapon revert, you can create a config file ca
 ```
 sm_reverts__item_<name> 1/0
 ```
-The below would disable the equalizer and sandman reverts
+
+The below would disable the Equalizer and Sandman reverts
 ```
 sm_reverts__item_equalizer 0
 sm_reverts__item_sandman 0
 ```
 
+Some reverts have multiple variants and can be set to values larger than 1 to use different versions. An example is the Soda Popper, which has two revert variants:
+```
+sm_reverts__item_sodapop 2/1
+```
+
 To get the name to use, open up the reverts.sp file and find the `ItemDefine` block near the top inside of OnPluginStart, and use the second value in the params.
 
-By default, all reverts are on. 
+By default, all reverts are on with value 1.
 
 ## Additional Credits
 Some or all of these plugins have been modified in some way, sometimes in major ways. I do not claim credit for these plugins and all credit goes to their original creators.

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -463,7 +463,7 @@ public void OnPluginStart() {
 	ItemDefine("Scottish Resistance", "scottish", "Reverted to release, 0.4 arm time penalty (from 0.8), no fire rate bonus", CLASSFLAG_DEMOMAN, Wep_Scottish);
 	ItemDefine("Short Circuit", "circuit", "Reverted to pre-matchmaking, alt fire destroys projectiles in front, costs 15 metal per shot", CLASSFLAG_ENGINEER, Wep_ShortCircuit);
 	ItemDefine("Shortstop", "shortstop", "Reverted to pre-Manniversary, fast reload, no push force penalty, shares pistol ammo; modern shove is kept", CLASSFLAG_SCOUT, Wep_Shortstop);
-	ItemDefine("Soda Popper", "sodapop", "Reverted to pre-Smissmas 2013, run to build hype and auto gain minicrits", CLASSFLAG_SCOUT, Wep_SodaPopper, 2);
+	ItemDefine("Soda Popper", "sodapop", "Reverted to pre-Smissmas 2013, run to build hype and auto gain minicrits", CLASSFLAG_SCOUT, Wep_SodaPopper, 1);
 	ItemVariant(Wep_SodaPopper, "Reverted to pre-matchmaking, run to build hype", 1);
 	ItemDefine("Solemn Vow", "solemn", "Reverted to pre-gunmettle, firing speed penalty removed", CLASSFLAG_MEDIC, Wep_Solemn);
 	ItemDefine("Splendid Screen", "splendid", "Reverted to pre-toughbreak, 15% blast resist, no faster recharge, crit after bash, no debuff removal, bash dmg at any range", CLASSFLAG_DEMOMAN, Wep_SplendidScreen);
@@ -4158,12 +4158,12 @@ void ParticleShowSimple(char[] name, float position[3]) {
 	}
 }
 
-void ItemDefine(char[] name, char[] key, char[] desc, int flags, int wep_enum, int num_variants = 1) {
+void ItemDefine(char[] name, char[] key, char[] desc, int flags, int wep_enum, int num_variants = 0) {
 	strcopy(items[wep_enum].key, sizeof(items[].key), key);
 	strcopy(items[wep_enum].name, sizeof(items[].name), name);
 	strcopy(items_desc[wep_enum][0], sizeof(items_desc[][]), desc);
 	items[wep_enum].flags = flags;
-	items[wep_enum].num_variants = (num_variants >= 1) ? num_variants : 1;
+	items[wep_enum].num_variants = (num_variants >= 0) ? num_variants : 0;
 }
 
 void ItemVariant(int wep_enum, char[] desc, int variant_idx) {
@@ -4183,7 +4183,7 @@ void ItemFinalize() {
 		Format(cvar_name, sizeof(cvar_name), "sm_reverts__item_%s", items[idx].key);
 		Format(cvar_desc, sizeof(cvar_desc), (PLUGIN_NAME ... " - Revert nerfs to %s"), items[idx].name);
 
-		items[idx].cvar = CreateConVar(cvar_name, "1", cvar_desc, FCVAR_NOTIFY, true, 0.0, true, float(items[idx].num_variants));
+		items[idx].cvar = CreateConVar(cvar_name, "1", cvar_desc, FCVAR_NOTIFY, true, 0.0, true, float(items[idx].num_variants + 1));
 	}
 }
 


### PR DESCRIPTION
### Summary of changes
Add support for revert variants that can be toggled at runtime (e.g. pre-2013 and pre-MyM Soda Popper)

Soda Popper
 - +50% faster firing speed
 - 25% faster reload time
 - -66% clip size
 - Builds Hype as you run.
 - When full, Alt-Fire to activate Hype mode for multiple air jumps.
 - This weapon reloads its entire clip at once

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Seems to work, I want more opinions on this

### Other Info
Revert descriptions are moved to a separate variable because enum structs don't seem to support multidimensional arrays