### PR TITLE
(Reverts) Rebased More Revert Variants + New Reverts

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -328,6 +328,7 @@ enum
 	Wep_Pomson,
 	Wep_Powerjack,
 	Wep_QuickFix,
+	Wep_Quickiebomb,
 	Wep_Razorback,
 	Wep_RescueRanger,
 	Wep_ReserveShooter,
@@ -470,6 +471,7 @@ public void OnPluginStart() {
 #else
 	ItemDefine("Quick-Fix", "quickfix", "Reverted to pre-matchmaking, +25% uber build rate", CLASSFLAG_MEDIC, Wep_QuickFix);
 #endif
+	ItemDefine("Quickiebomb Launcher", "quickiebomb", "Reverted to toughbreak, max charge time decreased by 50%, up to +25% damage based on charge, -25% clip size, stickies fizzle 4 seconds after landing", CLASSFLAG_DEMOMAN, Wep_Quickiebomb);
 	ItemDefine("Razorback","razorback","Reverted to pre-inferno, can be overhealed, shield does not regenerate", CLASSFLAG_SNIPER, Wep_Razorback);
 #if defined VERDIUS_PATCHES
 	ItemDefine("Rescue Ranger", "rescueranger", "Reverted to pre-gunmettle, heals +75 flat, no metal cost, 130 cost long ranged pickups", CLASSFLAG_ENGINEER, Wep_RescueRanger);
@@ -2142,6 +2144,15 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetNumAttributes(item1, 1);
 			TF2Items_SetAttribute(item1, 0, 10, 1.25); // +25% ÜberCharge rate
 		}}
+		case 1150: { if (ItemIsEnabled(Wep_Quickiebomb)) {
+			item1 = TF2Items_CreateItem(0);
+			TF2Items_SetFlags(item1, (OVERRIDE_ATTRIBUTES|PRESERVE_ATTRIBUTES));
+			TF2Items_SetNumAttributes(item1, 4); // attributes ported from NotnHeavy's pre-Gun Mettle plugin
+			TF2Items_SetAttribute(item1, 0, 727, 1.25); // Up to +25% damage based on charge
+			TF2Items_SetAttribute(item1, 1, 3, 0.75); // -25% clip size
+			TF2Items_SetAttribute(item1, 2, 669, 4.00); // Stickybombs fizzle 4 seconds after landing
+			TF2Items_SetAttribute(item1, 3, 670, 0.50); // Max charge time decreased by 50%
+		}}		
 #if defined VERDIUS_PATCHES
 		case 997: { if (ItemIsEnabled(Wep_RescueRanger)) {
 			item1 = TF2Items_CreateItem(0);
@@ -2653,6 +2664,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 214: player_weapons[client][Wep_Powerjack] = true;
 						case 404: player_weapons[client][Wep_Persian] = true;
 						case 411: player_weapons[client][Wep_QuickFix] = true;
+						case 1150: player_weapons[client][Wep_Quickiebomb] = true;
 						case 997: player_weapons[client][Wep_RescueRanger] = true;
 						case 415: player_weapons[client][Wep_ReserveShooter] = true;
 						case 59: player_weapons[client][Wep_DeadRinger] = true;


### PR DESCRIPTION
### Summary of changes
Make sure to disable release Gunboats and Quickiebomb Launcher reverts in the servers

Also edited itemdefine descriptions for Equalizer/Escape Plan and Powerjack.

Added nine (9) variants for: (scroll down for more details)
- [x] Tomislav
- [x] Enforcer
- [x] Eviction Notice
   - [x] tested with Steak speed boost capped at 310.5 HU/s
- [x] Pomson 6000 (note: interaction with reverted dead ringer not tested)
- [x] GRU
- [x] Powerjack (2 variants)
   - [x] Powerjack (release)
   - [x] Powerjack (Hatless Update)
- [x] Equalizer (2 variants)
   - [x] Equalizer (pre-Hatless Update)
   - [x] Equalizer (release)

Added two (2) new reverts:
- [x] Gunboats (Release version, make sure to disable this since no one asked for this)
- [x] Quickiebomb Launcher (Tough Break/pre-MyM version, ported from NotnHeavy's plugin)

### Testing Attestation
- [x] - This change has been quickly tested (Windows)
- [x] - This change has been thoroughly tested in itemtest with bots (Windows)
- [ ] - This change has been tested thoroughly by other contributors

### Description of testing
~~Only quickly tested, not thoroughly tested for each. These seem to work without breaking the base reverts.~~
~~Will thoroughly test again soon, but I need confirmation if these work on your end~~
Tested these variants again on my machine, seems to work without causing issues when toggled between variants.

### Other Attestations
- ~~The plugin version number has been incremented (if applicable)~~

### Other Info
Rebased #147 more revert variants because of #144


Variants added:
- **Tough Break Quickiebomb Launcher**
   - -0.2 sec faster bomb arm time
   - Max charge time decreased by 50%
   - Up to +25% damage based on charge
   - Able to destroy enemy stickybombs
   - -25% clip size
   - -15% damage penalty
   - Stickybombs fizzle 4 seconds after landing	
- **Release Tomislav**
   - +75% faster spin-up time, no accuracy bonus
- **Release Enforcer**
   - No firing speed penalty
   - +20% damage bonus regardless if disguised or not
   - Random crits enabled
   - +0.5 s increased time to fully cloak penalty
   - No piercing
- **Gun Mettle Eviction Notice**
   - +50% faster firing speed
   - Gain a speed boost on hit
   - -60% damage penalty
   - No increased move speed bonus
   - No damage vulnerability penalty
- **Release Pomson 6000**
   - Projectile goes through enemies
   - Projectile can hit enemies multiple times
   - Acts like Righteous Bison projectile
   - Note: does not ignore Vaccinator resistances yet (need to find out how to turn into Untyped damage)
- **Release Gunboats**
   - -75% blast self-damage
- **Release GRU**
   - No health drain penalty
   - No mark-for-death
   - 50% dmg penalty
   - -6hp/s while active, can jump a bit higher for every -6 hp lost per second
- **Powerjack variants**
   - **NOTE: These Powerjack variants used to synergize with the old Gas Jockey set bonus that gave you a passive +10% move speed bonus regardless of what weapon was active**
   - **Release Powerjack**
      - No faster move speed while active
      - Kills restore 75 health with overheal
      - +25% damage bonus
      - No random crits
   - **Hatless Update Powerjack**
      - No faster move speed while active
      - Kills restore 75 health with overheal
      - 25% melee vuln while active
- **Equalizer variants**
     - **For reference, this is the pre-Pyromania Equalizer currently used in the server** 
        - 107 dmg at 1 hp
           - https://wiki.teamfortress.com/w/index.php?title=Equalizer&oldid=1048826
     - **Pre-Hatless Update Equalizer (pre-April 14, 2010)** 
        - 113 dmg at 1 hp (does not one shot light classes since RDS is turned off by default)
           - IF -+15% RANDOM DAMAGE SPREAD IS TURNED ON: 
              - MAX 129 DMG (one-shots 125HP classes)
              - MIN 96 DMG
           - https://wiki.teamfortress.com/w/index.php?title=Equalizer&oldid=456483
     - **Release Equalizer (damage numbers shown assume 200 max HP)**
        - 125 dmg at 58 hp (one-shots unbuffed Scout, Spy, stock Engineer, and Sniper)
        - 150 dmg at 20 hp (one-shots unbuffed Medics)
        - 162 dmg at 1 hp (two-shots unbuffed Heavies)
           - This and the pre-Hatless Update versions of the Equalizer (and with random damage spread on by default back then) are what got stuck inside the collective consciousness of the TF2 community, and it didn't help _that certain popular figures who never experienced them and did not do enough research_ just regurgitated the old memories of these versions of the Equalizer. Remember to not trust anyone, and always do your own research.
           - https://web.archive.org/web/20100328111803/http://www.tf2wiki.net:80/wiki/Equalizer
