### PR TITLE
(Revert) Add release Baby Face's Blaster variant

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4489,14 +4489,14 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 		IsClientInGame(entity)
 	) {
 		if (TF2_GetPlayerClass(entity) == TFClass_Scout) {
+			float multiplier = 1.0;
 			if (
 				ItemIsEnabled(Wep_CritCola) &&
 				TF2_IsPlayerInCondition(entity, TFCond_CritCola) &&
 				player_weapons[entity][Wep_CritCola]
 			) {
 				// Crit-a-Cola speed boost.
-				returnValue.Value = view_as<float>(returnValue.Value) * 1.25;
-				return_val = MRES_Override;
+				multiplier *= 1.25;
 			}
 
 			if (
@@ -4506,7 +4506,12 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 				// Release Baby Face's Blaster proper speed application.
 				// Without this, the max boost speed would be only 376 HU/s, so we boost it further by ~38% at max boost
 				float boost = GetEntPropFloat(entity, Prop_Send, "m_flHypeMeter");
-				returnValue.Value = view_as<float>(returnValue.Value) * ValveRemapVal(boost, 0.0, 100.0, 1.0, 1.3829787);  
+				multiplier *= ValveRemapVal(boost, 0.0, 100.0, 1.0, 1.3829787);
+			}
+
+			if (multiplier != 1.0)
+			{
+				returnValue.Value = view_as<float>(returnValue.Value) * multiplier;
 				return_val = MRES_Override;
 			}
 		}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4481,7 +4481,6 @@ MRESReturn DHookCallback_CTFBaseRocket_GetRadius(int entity, Handle return_) {
 }
 
 MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn returnValue) {
-	MRESReturn return_val = MRES_Ignored;
 	if (
 		entity >= 1 &&
 		entity <= MaxClients &&
@@ -4512,7 +4511,7 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 			if (multiplier != 1.0)
 			{
 				returnValue.Value = view_as<float>(returnValue.Value) * multiplier;
-				return_val = MRES_Override;
+				return MRES_Override;
 			}
 		}
 
@@ -4536,12 +4535,12 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 					// Change the speed to 310.5 HU/s when Buffalo Steak Sandvich is used.
 					// Note: The speedboost for the Eviction Notice gets capped at 310.5 HU/s whenever the Steak buff is in effect. This happpens too with Vanilla.
 					returnValue.Value = view_as<float>(returnValue.Value) * 1.038;
-					return_val = MRES_Override;
+					return MRES_Override;
 				}
 			}
 		}
 	}
-	return return_val;
+	return MRES_Ignored;
 }
 
 MRESReturn DHookCallback_CTFPlayer_CanDisguise(int entity, Handle return_) {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3739,8 +3739,10 @@ public Action OnPlayerRunCmd(
 			{
 				case true:
 				{
-					if (!players[client].player_jumped)
-					{
+					if (
+						!players[client].player_jumped &&
+						GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 // don't reset if swimming
+					) {
 						SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);
 						// apply the following so movement gets reset immediately, maybe there's a better way
 						TF2Attrib_AddCustomPlayerAttribute(client, "move speed penalty", 0.99, 0.001);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3739,12 +3739,12 @@ public Action OnPlayerRunCmd(
 			{
 				case true:
 				{
-					if (
-						!players[client].player_jumped &&
-						GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0
-					) {
-						if (GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1) // don't reset if swimming
-						{
+					if (!players[client].player_jumped)
+					{
+						if (
+							GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0 && 
+							GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 // don't reset if swimming 
+						) {
 							SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);
 							// apply the following so movement gets reset immediately, maybe there's a better way
 							TF2Attrib_AddCustomPlayerAttribute(client, "move speed penalty", 0.99, 0.001);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3744,8 +3744,9 @@ public Action OnPlayerRunCmd(
 						if (
 							GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0 && 
 							GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 && // don't reset if swimming 
-							(buttons & IN_DUCK == 0) // don't reset if crouching,
-							// the attrib for reducing boost will reset it when air jumping while crouched
+							buttons & IN_DUCK == 0 && // don't reset if crouching
+							(GetEntityFlags(client) & FL_ONGROUND) != 0 // don't reset if airborne
+							// the attrib for reducing boost will reset for air jumps
 						) {
 							SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);
 							// apply the following so movement gets reset immediately, maybe there's a better way

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3741,12 +3741,14 @@ public Action OnPlayerRunCmd(
 				{
 					if (
 						!players[client].player_jumped &&
-						GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0 &&
-						GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 // don't reset if swimming
+						GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0
 					) {
-						SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);
-						// apply the following so movement gets reset immediately, maybe there's a better way
-						TF2Attrib_AddCustomPlayerAttribute(client, "move speed penalty", 0.99, 0.001);
+						if (GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1) // don't reset if swimming
+						{
+							SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);
+							// apply the following so movement gets reset immediately, maybe there's a better way
+							TF2Attrib_AddCustomPlayerAttribute(client, "move speed penalty", 0.99, 0.001);
+						}
 						players[client].player_jumped = true;
 					}
 				}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3741,6 +3741,7 @@ public Action OnPlayerRunCmd(
 				{
 					if (
 						!players[client].player_jumped &&
+						GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0 &&
 						GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 // don't reset if swimming
 					) {
 						SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -407,8 +407,8 @@ public void OnPluginStart() {
 	ItemDefine("Backburner", "backburner", "Reverted to Hatless update, 10% damage bonus", CLASSFLAG_PYRO, Wep_Backburner);
 	ItemVariant(Wep_Backburner, "Reverted to 119th update, 20% damage bonus, no airblast");
 	ItemDefine("B.A.S.E. Jumper", "basejump", "Reverted to pre-toughbreak, can redeploy, more air control, while deployed float mid-air when on fire", CLASSFLAG_SOLDIER | CLASSFLAG_DEMOMAN, Wep_BaseJumper);
-	ItemDefine("Baby Face's Blaster", "babyface", "Reverted to pre-gunmettle, no boost loss on damage, only -25% on jump", CLASSFLAG_SCOUT, Wep_BabyFace);
-	ItemVariant(Wep_BabyFace, "Reverted to release, +40% accuracy, no clip penalty or boost loss on hit, -35% movespeed, -30% damage, -100% on jump");
+	ItemDefine("Baby Face's Blaster", "babyface", "Reverted to pre-gunmettle, no boost loss on damage, only -25% on air jump", CLASSFLAG_SCOUT, Wep_BabyFace);
+	ItemVariant(Wep_BabyFace, "Reverted to release, +40% accuracy, no clip penalty or boost loss on hit, -35% movespeed, -30% damage, -100% on any jump");
 	ItemDefine("Beggar's Bazooka", "beggars", "Reverted to pre-2013, no radius penalty, misfires don't remove ammo clip", CLASSFLAG_SOLDIER, Wep_Beggars);
 	ItemDefine("Black Box", "blackbox", "Reverted to pre-gunmettle, flat +15 per hit at any range, uncapped", CLASSFLAG_SOLDIER, Wep_BlackBox);
 	ItemDefine("Bonk! Atomic Punch", "bonk", "Reverted to pre-inferno, no longer slows after the effect wears off", CLASSFLAG_SCOUT, Wep_Bonk);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3743,7 +3743,9 @@ public Action OnPlayerRunCmd(
 					{
 						if (
 							GetEntPropFloat(client, Prop_Send, "m_flHypeMeter") > 0.0 && 
-							GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 // don't reset if swimming 
+							GetEntProp(client, Prop_Data, "m_nWaterLevel") <= 1 && // don't reset if swimming 
+							(buttons & IN_DUCK == 0) // don't reset if crouching,
+							// the attrib for reducing boost will reset it when air jumping while crouched
 						) {
 							SetEntPropFloat(client, Prop_Send, "m_flHypeMeter", 0.0);
 							// apply the following so movement gets reset immediately, maybe there's a better way

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1448,6 +1448,7 @@ public void OnGameFrame() {
 				players[idx].scout_airdash_value = 0;
 				players[idx].scout_airdash_count = 0;
 				players[idx].is_under_hype = false;
+				players[idx].player_jumped = false;
 			}
 		}
 	}
@@ -1517,7 +1518,6 @@ public void OnClientConnected(int client) {
 	players[client].medic_medigun_charge = 0.0;
 	players[client].parachute_cond_time = 0.0;
 	players[client].received_help_notice = false;
-	players[client].player_jumped = false;
 
 	for (int i = 0; i < NUM_ITEMS; i++) {
 		prev_player_weapons[client][i] = false;


### PR DESCRIPTION
### Summary of changes
Baby Face's Blaster
 - 40% more accurate
 - On Hit: Builds Boost
 - Run at up to double speed at maximum Boost
 - -30% damage penalty
 - 35% slower move speed on wearer
 - Boost resets on jump

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
N/A

### Other Info
N/A
