### PR TITLE
(Revert) Release Steak with GRU speed stacking & without speed stacking variants

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -418,7 +418,7 @@ public void OnPluginStart() {
 	ItemDefine("Brass Beast", "brassbeast", "Reverted to pre-matchmaking, 20% damage resistance (6.7% against crits) when spun up at any health", CLASSFLAG_HEAVY, Wep_BrassBeast);
 	ItemDefine("Bushwacka", "bushwacka", "Reverted to pre-love&war, 20% fire vuln at all times, random crits enabled", CLASSFLAG_SNIPER, Wep_Bushwacka);
 	ItemDefine("Buffalo Steak Sandvich", "buffalosteak", "Reverted to pre-matchmaking, immediately gain +35% faster move speed and 10% dmg vuln while buffed", CLASSFLAG_HEAVY, Wep_BuffaloSteak);
-	ItemVariant(Wep_BuffaloSteak, "Reverted to release, +35% faster move speed on use, mini-crits on dmg taken by wearer, speed multiplicatively stacks with GRU to 403.65 HU/s (+75.5%, run a bit faster than Scout)");
+	ItemVariant(Wep_BuffaloSteak, "Reverted to release, +35% faster move speed on use, mini-crits on dmg taken by wearer, speed stacks with GRU (run a bit faster than Scout)");
 	ItemDefine("Chargin' Targe", "targe", "Reverted to pre-toughbreak, 40% blast resistance, afterburn immunity, crit after bash, no debuff removal", CLASSFLAG_DEMOMAN, Wep_CharginTarge);
 	ItemDefine("Claidheamh Mòr", "claidheamh", "Reverted to pre-toughbreak, -15 health, no damage vuln, longer charge is passive", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
 	ItemDefine("Cleaner's Carbine", "carbine", "Reverted to release, crits for 3 seconds on kill", CLASSFLAG_SNIPER, Wep_CleanerCarbine);
@@ -4663,6 +4663,16 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 			{
 				int index = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
 
+				// release steak + GRU move speed stacking imitation code
+				// resulting speed should be 403.65 HU/s since old GRU + Buffalo Steak speed stack was 403.65 HU/s (230*1.30*1.35)
+				// note: whip speedboost doesn't stack with old steak + GRU speed stacking. the same behavior also exists for vanilla steak + GRU.
+				if(GetItemVariant(Wep_BuffaloSteak) == 1 && (index == 239 || index == 1084 || index == 1100)) {				
+					returnValue.Value = view_as<float>(returnValue.Value) * 1.30; 
+					// it rounds to 403.50 HU/s for some reason via cl_showpos 1, i gave up trying to get it to the exact value but this should be good enough
+					// technically 403.50 HU/s isn't historically accurate, but i have no idea why i can't get it to 403.65 HU/s despite setting it to exactly that value before
+					return MRES_Override;	
+				}
+
 				if (!(index == 239 || index == 1084 || index == 1100 || (index == 426 && GetItemVariant(Wep_Eviction) == 0)))
 				{
 					// Change the speed to 310.5 HU/s when Buffalo Steak Sandvich is used.
@@ -4678,18 +4688,6 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 						returnValue.Value = view_as<float>(returnValue.Value) * 1.00;
 						return MRES_Override;
 					}				
-	
-					// clean this up later!!!
-					// release steak + GRU move speed stacking imitation code
-					else if(GetItemVariant(Wep_BuffaloSteak) == 1) {
-						if(index == 239 || index == 1084 || index == 1100) {
-							// resulting speed should be 403.65 HU/s since old GRU + Buffalo Steak speed stack was 403.65 HU/s (230*1.30*1.35)
-							// don't care about speedboost from disciplinary action, disciplinary action (2011) and old steak+GRU stacking (2010) never existed with each other in the past
-							returnValue.Value = view_as<float>(returnValue.Value) * 1.35;
-							return MRES_Override;
-						}
-						// eviction notice speed boost doesn't matter i think with the release steak
-					}
 					
 					else returnValue.Value = view_as<float>(returnValue.Value) * 1.038;
 					return MRES_Override;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4667,6 +4667,7 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 				{
 					// Change the speed to 310.5 HU/s when Buffalo Steak Sandvich is used.
 					// Note: The speedboost for the Eviction Notice gets capped at 310.5 HU/s whenever the reverted Steak buff is in effect. This happpens too with Vanilla.	
+					// initial returnValue.Value = ~299 HU/s
 					if ((index == 426) && (GetItemVariant(Wep_Eviction) == 1) && TF2_IsPlayerInCondition(entity, TFCond_SpeedBuffAlly)) {
 						// Cap speed to 310.5 HU/s when speedboost on hit is active while under reverted Steak buff for the Gun Mettle variant of the Eviction Notice
 						returnValue.Value = view_as<float>(returnValue.Value) * 1.00;
@@ -4677,6 +4678,19 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 						returnValue.Value = view_as<float>(returnValue.Value) * 1.00;
 						return MRES_Override;
 					}				
+	
+					// clean this up later!!!
+					// release steak + GRU move speed stacking imitation code
+					else if(GetItemVariant(Wep_BuffaloSteak) == 1) {
+						if(index == 239 || index == 1084 || index == 1100) {
+							// resulting speed should be 403.65 HU/s since old GRU + Buffalo Steak speed stack was 403.65 HU/s (230*1.30*1.35)
+							// don't care about speedboost from disciplinary action, disciplinary action (2011) and old steak+GRU stacking (2010) never existed with each other in the past
+							returnValue.Value = view_as<float>(returnValue.Value) * 1.35;
+							return MRES_Override;
+						}
+						// eviction notice speed boost doesn't matter i think with the release steak
+					}
+					
 					else returnValue.Value = view_as<float>(returnValue.Value) * 1.038;
 					return MRES_Override;
 				}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1703,7 +1703,6 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 	{
 		// buffalo steak sandvich minicrit on damage taken
 		// steak sandvich buff effect is composed of TFCond_CritCola and TFCond_RestrictToMelee according to the released source code
-		// source code states the present buff effect lasts for 16 seconds, 2 seconds for taunt but the wiki states the taunt lasts 4.3 seconds 
 		if (
 			ItemIsEnabled(Wep_BuffaloSteak) &&
 			(GetItemVariant(Wep_BuffaloSteak) == 1 || GetItemVariant(Wep_BuffaloSteak) == 2) &&
@@ -1711,7 +1710,7 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 			condition == TFCond_RestrictToMelee &&
 			TF2_IsPlayerInCondition(client, TFCond_CritCola)
 		) {			
-			TF2_AddCondition(client, TFCond_MarkedForDeathSilent); //historically didn't have the Marked-for-Death symbol, but this will be fine for now
+			TF2_AddCondition(client, TFCond_MarkedForDeathSilent); // historically didn't have the Marked-for-Death symbol in HUD, but a visual cue is good
 		}
 	}
 
@@ -1731,7 +1730,7 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 	}
 
 	{
-		//buffalo steak sandvich marked-for-death effect removal
+		// buffalo steak sandvich marked-for-death effect removal
 		if (
 			ItemIsEnabled(Wep_BuffaloSteak) &&
 			(GetItemVariant(Wep_BuffaloSteak) == 1 || GetItemVariant(Wep_BuffaloSteak) == 2) &&
@@ -4664,7 +4663,7 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 			{
 				int index = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
 
-				// release steak + GRU move speed stacking imitation code
+				// Release steak + GRU move speed stacking imitation code
 				// resulting speed should be 403.65 HU/s since old GRU + Buffalo Steak speed stack was 403.65 HU/s (230*1.30*1.35)
 				// note: whip speedboost doesn't stack with old steak + GRU speed stacking. the same behavior also exists for vanilla steak + GRU.
 				if(GetItemVariant(Wep_BuffaloSteak) == 1 && (index == 239 || index == 1084 || index == 1100)) {				
@@ -4689,7 +4688,7 @@ MRESReturn DHookCallback_CTFPlayer_CalculateMaxSpeed(int entity, DHookReturn ret
 						returnValue.Value = view_as<float>(returnValue.Value) * 1.00;
 						return MRES_Override;
 					}				
-					
+					// increase speed to 310.5 HU/s
 					else returnValue.Value = view_as<float>(returnValue.Value) * 1.038;
 					return MRES_Override;
 				}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -419,6 +419,7 @@ public void OnPluginStart() {
 	ItemDefine("Bushwacka", "bushwacka", "Reverted to pre-love&war, 20% fire vuln at all times, random crits enabled", CLASSFLAG_SNIPER, Wep_Bushwacka);
 	ItemDefine("Buffalo Steak Sandvich", "buffalosteak", "Reverted to pre-matchmaking, immediately gain +35% faster move speed and 10% dmg vuln while buffed", CLASSFLAG_HEAVY, Wep_BuffaloSteak);
 	ItemVariant(Wep_BuffaloSteak, "Reverted to release, +35% faster move speed on use, mini-crits on dmg taken by wearer, speed stacks with GRU (run a bit faster than Scout)");
+	ItemVariant(Wep_BuffaloSteak, "Reverted to pre-Summer 2013, +35% faster move speed on use, mini-crits on dmg taken by wearer, speed does not stack with GRU");
 	ItemDefine("Chargin' Targe", "targe", "Reverted to pre-toughbreak, 40% blast resistance, afterburn immunity, crit after bash, no debuff removal", CLASSFLAG_DEMOMAN, Wep_CharginTarge);
 	ItemDefine("Claidheamh Mòr", "claidheamh", "Reverted to pre-toughbreak, -15 health, no damage vuln, longer charge is passive", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
 	ItemDefine("Cleaner's Carbine", "carbine", "Reverted to release, crits for 3 seconds on kill", CLASSFLAG_SNIPER, Wep_CleanerCarbine);
@@ -1705,7 +1706,7 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 		// source code states the present buff effect lasts for 16 seconds, 2 seconds for taunt but the wiki states the taunt lasts 4.3 seconds 
 		if (
 			ItemIsEnabled(Wep_BuffaloSteak) &&
-			GetItemVariant(Wep_BuffaloSteak) == 1 &&
+			(GetItemVariant(Wep_BuffaloSteak) == 1 || GetItemVariant(Wep_BuffaloSteak) == 2) &&
 			TF2_GetPlayerClass(client) == TFClass_Heavy &&
 			condition == TFCond_RestrictToMelee &&
 			TF2_IsPlayerInCondition(client, TFCond_CritCola)
@@ -1733,7 +1734,7 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 		//buffalo steak sandvich marked-for-death effect removal
 		if (
 			ItemIsEnabled(Wep_BuffaloSteak) &&
-			GetItemVariant(Wep_BuffaloSteak) == 1 &&
+			(GetItemVariant(Wep_BuffaloSteak) == 1 || GetItemVariant(Wep_BuffaloSteak) == 2) &&
 			TF2_GetPlayerClass(client) == TFClass_Heavy &&
 			!TF2_IsPlayerInCondition(client, TFCond_CritCola) &&
 			!TF2_IsPlayerInCondition(client, TFCond_RestrictToMelee) &&
@@ -1886,7 +1887,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 311: { if (ItemIsEnabled(Wep_BuffaloSteak)) {
 			item1 = TF2Items_CreateItem(0);
 			TF2Items_SetFlags(item1, (OVERRIDE_ATTRIBUTES|PRESERVE_ATTRIBUTES));
-			bool releaseVer = GetItemVariant(Wep_BuffaloSteak) == 1;
+			bool releaseVer = (GetItemVariant(Wep_BuffaloSteak) > 0);
 			TF2Items_SetNumAttributes(item1, 1);
 			if(!releaseVer)
 				TF2Items_SetAttribute(item1, 0, 798, 1.10); // +10% damage vulnerability while under the effect; energy_buff_dmg_taken_multiplier

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -418,6 +418,7 @@ public void OnPluginStart() {
 	ItemDefine("Brass Beast", "brassbeast", "Reverted to pre-matchmaking, 20% damage resistance (6.7% against crits) when spun up at any health", CLASSFLAG_HEAVY, Wep_BrassBeast);
 	ItemDefine("Bushwacka", "bushwacka", "Reverted to pre-love&war, 20% fire vuln at all times, random crits enabled", CLASSFLAG_SNIPER, Wep_Bushwacka);
 	ItemDefine("Buffalo Steak Sandvich", "buffalosteak", "Reverted to pre-matchmaking, immediately gain +35% faster move speed and 10% dmg vuln while buffed", CLASSFLAG_HEAVY, Wep_BuffaloSteak);
+	ItemVariant(Wep_BuffaloSteak, "Reverted to release, +35% faster move speed on use, mini-crits on dmg taken by wearer, speed multiplicatively stacks with GRU to 403.65 HU/s (+75.5%, run a bit faster than Scout)");
 	ItemDefine("Chargin' Targe", "targe", "Reverted to pre-toughbreak, 40% blast resistance, afterburn immunity, crit after bash, no debuff removal", CLASSFLAG_DEMOMAN, Wep_CharginTarge);
 	ItemDefine("Claidheamh Mòr", "claidheamh", "Reverted to pre-toughbreak, -15 health, no damage vuln, longer charge is passive", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
 	ItemDefine("Cleaner's Carbine", "carbine", "Reverted to release, crits for 3 seconds on kill", CLASSFLAG_SNIPER, Wep_CleanerCarbine);
@@ -1697,6 +1698,22 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 			TF2_AddCondition(client, TFCond_FireImmune, 2.0, 0);
 		}
 	}
+
+	{
+		// buffalo steak sandvich minicrit on damage taken
+		// steak sandvich buff effect is composed of TFCond_CritCola and TFCond_RestrictToMelee according to the released source code
+		// source code states the present buff effect lasts for 16 seconds, 2 seconds for taunt but the wiki states the taunt lasts 4.3 seconds 
+		if (
+			ItemIsEnabled(Wep_BuffaloSteak) &&
+			GetItemVariant(Wep_BuffaloSteak) == 1 &&
+			TF2_GetPlayerClass(client) == TFClass_Heavy &&
+			condition == TFCond_RestrictToMelee &&
+			TF2_IsPlayerInCondition(client, TFCond_CritCola)
+		) {			
+			TF2_AddCondition(client, TFCond_MarkedForDeathSilent); //historically didn't have the Marked-for-Death symbol, but this will be fine for now
+		}
+	}
+
 }
 
 public void TF2_OnConditionRemoved(int client, TFCond condition) {
@@ -1711,6 +1728,21 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 			TF2_AddCondition(client, TFCond_CritCola, 11.0, 0);
 		}
 	}
+
+	{
+		//buffalo steak sandvich marked-for-death effect removal
+		if (
+			ItemIsEnabled(Wep_BuffaloSteak) &&
+			GetItemVariant(Wep_BuffaloSteak) == 1 &&
+			TF2_GetPlayerClass(client) == TFClass_Heavy &&
+			!TF2_IsPlayerInCondition(client, TFCond_CritCola) &&
+			!TF2_IsPlayerInCondition(client, TFCond_RestrictToMelee) &&
+			TF2_IsPlayerInCondition(client, TFCond_MarkedForDeathSilent)
+		) {
+			TF2_RemoveCondition(client, TFCond_MarkedForDeathSilent);
+		}			
+	}
+
 }
 
 public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &provider) {
@@ -1854,8 +1886,13 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 311: { if (ItemIsEnabled(Wep_BuffaloSteak)) {
 			item1 = TF2Items_CreateItem(0);
 			TF2Items_SetFlags(item1, (OVERRIDE_ATTRIBUTES|PRESERVE_ATTRIBUTES));
+			bool releaseVer = GetItemVariant(Wep_BuffaloSteak) == 1;
 			TF2Items_SetNumAttributes(item1, 1);
-			TF2Items_SetAttribute(item1, 0, 798, 1.10); // +10% damage vulnerability while under the effect; energy_buff_dmg_taken_multiplier
+			if(!releaseVer)
+				TF2Items_SetAttribute(item1, 0, 798, 1.10); // +10% damage vulnerability while under the effect; energy_buff_dmg_taken_multiplier
+			if(releaseVer)
+				TF2Items_SetAttribute(item1, 0, 798, 1.00); // 0% damage vulnerability while under the effect; energy_buff_dmg_taken_multiplier
+				// mini-crits on damage taken handled elsewhere in TF2_OnConditionAdded and TF2_OnConditionRemoved
 		}}
 		case 232: { if (ItemIsEnabled(Wep_Bushwacka)) {
 			item1 = TF2Items_CreateItem(0);


### PR DESCRIPTION
### Summary of changes
Heavy can run as fast as the Scout again.

Added the following revert variants:
- Release Buffalo Steak Sandvich
   - When under effects:
      - Move speed increased to 310.5 HU/s
      - No damage vulnerability modifier
      - Instead, damage taken are mini-crits to the user (+35% damage vulnerability)
      - When combined with the GRU, move speed stacks and increases to 403.50 HU/s (run as fast as the Scout, just a tiny bit faster)
         - Speed should exactly be 403.65 HU/s historically, but due to rounding, it gets rounded down to 403.50 HU/s (according to cl_showpos 1)

- Pre-Summer 2013 Buffalo Steak Sandvich
   - Same stats as the release Steak, but without the speed stacking effect with the GRU

### Testing Attestation
- [x] - This change has been tested (Windows)
- [ ] - This change has not been tested, reasoning below

### Description of testing
Tested on Windows. Doesn't seem to break the default Steak revert.

### Other Info
This method of making the Heavy run faster than the Scout is done by setting the speed to 403.50 HU/s whenever the Heavy is under the release Steak's effects with whatever version of the GRU is used.

I have no idea why the move speed gets rounded to 403.50 HU/s instead of 403.65 HU/s. But since this is already a very minor difference, I think it should be fine to add it in.

As for why I think the speed is 403.50 HU/s, the TF2 wiki archive mentions that the stacked speed is around 400 HU/s (https://wiki.teamfortress.com/w/index.php?title=Buffalo_Steak_Sandvich&oldid=275360). This video also seems to show the Heavy keeping up with the Scout's speed: https://www.youtube.com/watch?v=7shqb9gmKm8

The source code shows that final move speed is multiplied (https://github.com/ValveSoftware/source-sdk-2013/blob/39f6dde8fbc238727c020d13b05ecadd31bda4c0/src/game/shared/tf/tf_player_shared.cpp#L10965C27-L10965C37). So unless I am misinterpreting things, the actual stacked move speed of the Heavy before the 310.5 HU/s speedcap was implemented was 403.65 HU/s.
```
...
float maxfbspeed = default_speed // should be equal to 230 for heavy
...
void CTFPlayer::TeamFortress_SetSpeed()
...	
	// If we're a heavy with berzerker mode...
	if ( playerclass == TF_CLASS_HEAVYWEAPONS )
	{
		float heavy_max_speed = default_speed * 1.35f;
		if ( m_Shared.InCond( TF_COND_ENERGY_BUFF ) )
		{
			maxfbspeed *= 1.3f; // this is why i think move speed was multiplied, which resulting in heavy moving as fast as the scout
			if ( maxfbspeed > heavy_max_speed ) // if GRU only then 299.0 > 310.5, but when combined when Steak, 403.65 > 310.5
			{
				// Prevent other speed modifiers like GRU from making berzerker mode too fast.
				maxfbspeed = heavy_max_speed;
				
			}
		}
	}
...
```


