### PR TITLE
(Reverts) Jag Reverts (Pre-Tough Break & Pre-Gun Mettle) and Eureka Effect (Pre-Gun Mettle)

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -321,6 +321,7 @@ enum
 	Wep_GRU,
 	Wep_Gunboats,
 	Wep_Zatoichi, // Half-Zatoichi
+	Wep_Jag,
 	Wep_LibertyLauncher,
 	Wep_LochLoad,
 	Wep_LooseCannon,
@@ -458,6 +459,8 @@ public void OnPluginStart() {
 	ItemVariant(Wep_GRU, "GlovesRU_1");
 	ItemDefine("gunboats", "Gunboats_0", CLASSFLAG_SOLDIER, Wep_Gunboats);
 	ItemDefine("zatoichi", "Zatoichi_0", CLASSFLAG_SOLDIER | CLASSFLAG_DEMOMAN, Wep_Zatoichi);
+	ItemDefine("jag", "Jag_0", CLASSFLAG_ENGINEER, Wep_Jag);
+	ItemVariant(Wep_Jag, "Jag_1");
 	ItemDefine("liberty", "Liberty_0", CLASSFLAG_SOLDIER, Wep_LibertyLauncher);
 	ItemDefine("lochload", "LochLoad_0", CLASSFLAG_DEMOMAN, Wep_LochLoad);
 	ItemVariant(Wep_LochLoad, "LochLoad_1");
@@ -1999,6 +2002,15 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetNumAttributes(itemNew, 1);
 			TF2Items_SetAttribute(itemNew, 0, 437, 65536.0); // crit vs stunned players
 		}}
+		case 329: { if (ItemIsEnabled(Wep_Jag)) {
+			bool preToughBreak = GetItemVariant(Wep_Jag) == 1;
+			TF2Items_SetNumAttributes(itemNew, preToughBreak ? 3 : 1);
+			TF2Items_SetAttribute(itemNew, 0, 775, 1.00); // -0% damage penalty vs buildings
+			if (preToughBreak) {
+				TF2Items_SetAttribute(itemNew, 1, 6, 1.00); // +0% faster firing speed
+				TF2Items_SetAttribute(itemNew, 2, 95, 1.00); // -0% slower repair rate
+			}
+		}}		
 		case 414: { if (ItemIsEnabled(Wep_LibertyLauncher)) {
 			TF2Items_SetNumAttributes(itemNew, 4);
 			TF2Items_SetAttribute(itemNew, 0, 1, 1.00); // damage penalty
@@ -2590,6 +2602,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 416: player_weapons[client][Wep_MarketGardener] = true;
 						case 239, 1084, 1100: player_weapons[client][Wep_GRU] = true;
 						case 812, 833: player_weapons[client][Wep_Cleaver] = true;
+						case 329: player_weapons[client][Wep_Jag] = true;
 						case 414: player_weapons[client][Wep_LibertyLauncher] = true;
 						case 308: player_weapons[client][Wep_LochLoad] = true;
 						case 41: player_weapons[client][Wep_Natascha] = true;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -314,6 +314,7 @@ enum
 	Wep_DragonFury,
 	Wep_Enforcer,
 	Wep_Pickaxe, // Equalizer
+	Wep_EurekaEffect,
 	Wep_Eviction,
 	Wep_FistsSteel,
 	Wep_Cleaver, // Flying Guillotine	
@@ -451,6 +452,7 @@ public void OnPluginStart() {
 	ItemDefine("equalizer", "Equalizer_0", CLASSFLAG_SOLDIER, Wep_Pickaxe);
 	ItemVariant(Wep_Pickaxe, "Equalizer_1");
 	ItemVariant(Wep_Pickaxe, "Equalizer_2");
+	ItemDefine("eureka", "Eureka_0", CLASSFLAG_ENGINEER, Wep_EurekaEffect);
 	ItemDefine("eviction", "Eviction_0", CLASSFLAG_HEAVY, Wep_Eviction);
 	ItemVariant(Wep_Eviction, "Eviction_1");
 	ItemDefine("fiststeel", "FistSteel_0", CLASSFLAG_HEAVY, Wep_FistsSteel);
@@ -1949,11 +1951,19 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 2, 740, 1.0); // reduced healing from medics
 			TF2Items_SetAttribute(itemNew, 3, index == 128 ? 115 : 235, 2.0); // mod shovel damage boost
 		}}
+		case 589: { if (ItemIsEnabled(Wep_EurekaEffect)) {
+			TF2Items_SetNumAttributes(itemNew, 5);
+			TF2Items_SetAttribute(itemNew, 0, 93, 1.00); // Construction hit speed boost decreased by 0%
+			TF2Items_SetAttribute(itemNew, 1, 732, 1.00); // 0% less metal from pickups and dispensers
+			TF2Items_SetAttribute(itemNew, 2, 790, 1.00); // -0% metal cost when constructing or upgrading teleporters
+			TF2Items_SetAttribute(itemNew, 3, 95, 0.50); // 50% slower repair rate
+			TF2Items_SetAttribute(itemNew, 4, 2043, 0.50); // 50% slower upgrade rate
+		}}
 		case 225, 574: { if (ItemIsEnabled(Wep_EternalReward)) {
 			TF2Items_SetNumAttributes(itemNew, 2);
 			TF2Items_SetAttribute(itemNew, 0, 34, 1.00); // mult cloak meter consume rate
 			TF2Items_SetAttribute(itemNew, 1, 155, 1.00); // cannot disguise
-		}}
+		}}		
 		case 426: { if (ItemIsEnabled(Wep_Eviction)) {
 			bool gunMettleVer = GetItemVariant(Wep_Eviction) == 1;
 			TF2Items_SetNumAttributes(itemNew, gunMettleVer ? 3 : 2);
@@ -2597,6 +2607,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 460: player_weapons[client][Wep_Enforcer] = true;
 						case 128, 775: player_weapons[client][Wep_Pickaxe] = true;
 						case 225, 574: player_weapons[client][Wep_EternalReward] = true;
+						case 589: player_weapons[client][Wep_EurekaEffect] = true;
 						case 426: player_weapons[client][Wep_Eviction] = true;
 						case 331: player_weapons[client][Wep_FistsSteel] = true;
 						case 416: player_weapons[client][Wep_MarketGardener] = true;

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -225,6 +225,10 @@
 	{
 		"en"	"Equalizer & Escape Plan"
 	}
+	"eureka"
+	{
+		"en"	"Eureka Effect"
+	}	
 	"eviction"
 	{
 		"en"	"Eviction Notice"
@@ -559,6 +563,10 @@
 	{
 		"en"	"Merged back to release; while active: blocks Medic healing, can't call for Medics, no mark-for-death; if 200 max hp: 125 dmg at 58 hp, 150 dmg at 20 hp, 162 dmg at 1 hp"
 	}
+	"Eureka_0"
+	{
+		"en"	"Reverted to pre-gunmettle, 50%% slower repair and upgrade rates, no construction hit boost decrease, no metal pickup penalty, no teleporter metal cost bonus"
+	}	
 	"Eviction_0"
 	{
 		"en"	"Reverted to pre-inferno, no health drain, +20%% damage taken"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -249,6 +249,10 @@
 	{
 		"en"	"Half-Zatoichi"
 	}
+	"jag"
+	{
+		"en"	"Jag"
+	}	
 	"liberty"
 	{
 		"en"	"Liberty Launcher"
@@ -587,6 +591,14 @@
 	{
 		"en"	"Reverted to pre-toughbreak, fast switch, less range, cannot switch until kill, full heal, has random crits"
 	}
+	"Jag_0"
+	{
+		"en"	"Reverted to pre-toughbreak, no damage penalty against buildings (destroy Sappers in 2 hits)"
+	}
+	"Jag_1"
+	{
+		"en"	"Reverted to pre-gunmettle, no damage penalty against buildings (destroy Sappers in 2 hits), no repair rate penalty, no faster firing speed bonus"
+	}	
 	"Liberty_0"
 	{
 		"en"	"Reverted to release, +40%% projectile speed, -25%% clip size"


### PR DESCRIPTION
### Summary of changes
Added Jag reverts and Eureka Effect revert.

**Disable these by default, unless you want the Jag revert.**
(honestly pre-gun mettle Eureka Effect is just bad in my opinion)

Attributes ported from NotnHeavy's pre-GM plugin


### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Tested in itemtest with puppet bots on Windows

### Other Info

https://wiki.teamfortress.com/w/index.php?title=Eureka_Effect&oldid=1831401
- **Eureka Effect (Pre-Gun Mettle)**
  - 50% slower repair rate
  - 50% slower upgrade rate
  - No construction hit boost decrease
  - No metal pickup penalty
  - No teleporter metal cost bonus
  - **Note: Engineer had class changes after pre-Gun Mettle which also affected construction speeds. This revert is not 100% accurate because the Gun Mettle changes aren't reverted.**

- **Jag (Pre-Tough Break)**
  - No damage penalty against buildings (destroy Sappers in 2 hits)

- **Jag (Pre-Gun Mettle)**
  - No damage penalty against buildings
  - No faster firing speed
  - No slower repair rate
  - **Note: This revert is not 100% accurate because of the base construction speed and other changes for the Engineer after Gun Mettle. Only the Pre-Tough Break version is accurate.**
