### PR TITLE
Add revert variants for Crit-a-Cola

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -422,6 +422,8 @@ public void OnPluginStart() {
 	ItemDefine("cozycamper","CozyCamper_PreMYM", CLASSFLAG_SNIPER, Wep_CozyCamper);
 #endif
 	ItemDefine("critcola", "CritCola_PreMYM", CLASSFLAG_SCOUT, Wep_CritCola);
+	ItemVariant(Wep_CritCola, "CritCola_PreJI");
+	ItemVariant(Wep_CritCola, "CritCola_PreDec2013");
 	ItemDefine("crocostyle", "CrocoStyle_Release", CLASSFLAG_SNIPER, Set_CrocoStyle);
 #if defined MEMORY_PATCHES
 	ItemDefine("dalokohsbar", "DalokohsBar_PreMYM", CLASSFLAG_HEAVY, Wep_Dalokoh);
@@ -1736,6 +1738,17 @@ public Action TF2_OnRemoveCond(int client, TFCond &condition, float &timeleft, i
 			}
 		}
 	}
+	{
+		// pre-inferno crit-a-cola mark-for-death on expire
+		if (
+			GetItemVariant(Wep_CritCola) == 1 &&
+			TF2_GetPlayerClass(client) == TFClass_Scout &&
+			condition == TFCond_CritCola &&
+			GetEntPropFloat(client, Prop_Send, "m_flEnergyDrinkMeter") <= 0.0
+		) {
+			TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 2.0, 0);
+		}
+	}
 	return Plugin_Continue;
 }
 
@@ -1859,7 +1872,9 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
 			TF2Items_SetNumAttributes(itemNew, 2);
 			TF2Items_SetAttribute(itemNew, 0, 814, 0.0); // no mark-for-death on attack
-			TF2Items_SetAttribute(itemNew, 1, 798, 1.10); // +10% damage vulnerability while under the effect
+			// +25% or +10% damage vulnerability while under the effect, depending on variant
+			float vuln = GetItemVariant(Wep_CritCola) == 2 ? 1.25 : 1.10;
+			TF2Items_SetAttribute(itemNew, 1, 798, vuln);
 		}}
 		case 231: { if (ItemIsEnabled(Wep_Darwin)) {
 			bool dmg_mods = GetItemVariant(Wep_Darwin) == 1;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2787,11 +2787,16 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 				GetItemVariant(Wep_SodaPopper) == 0 &&
 				players[client].is_under_hype
 			) {
-				bool has_lunchbox = (player_weapons[client][Wep_Bonk] || player_weapons[client][Wep_CritCola]);
-				if (has_lunchbox)
-				{
+				if (player_weapons[client][Wep_SodaPopper]) {
+					if (
+						player_weapons[client][Wep_Bonk] ||
+						player_weapons[client][Wep_CritCola]
+					){
+						players[client].is_under_hype = false;
+						TF2_AddCondition(client, TFCond_CritHype, 11.0, 0);
+					}
+				} else {
 					players[client].is_under_hype = false;
-					TF2_AddCondition(client, TFCond_CritHype, 11.0, 0);
 				}
 			}
 		}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1671,6 +1671,17 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 		}
 	}
 
+	{
+		// crit-a-cola damage taken minicrits
+		if (
+			(GetItemVariant(Wep_CritCola) == 3 || GetItemVariant(Wep_CritCola) == 4) &&
+			TF2_GetPlayerClass(client) == TFClass_Scout &&
+			condition == TFCond_CritCola &&
+			player_weapons[client][Wep_CritCola] == true
+		) {
+			TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 8.0, 0);
+		}
+	}
 }
 
 public void TF2_OnConditionRemoved(int client, TFCond condition) {
@@ -1732,23 +1743,15 @@ public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &pro
 	}
 	{
 		// crit-a-cola release variant duration modification
-		// also mark the user for death for pre-July2013 and release variants
-		// historically didn't have the Marked-for-Death symbol in HUD, but a visual cue is good
-		int item_variant = GetItemVariant(Wep_CritCola);
+		// crit-a-cola normally applies 9 seconds, then relies on the energy drink meter to have it be 8 seconds
 		if (
-			(item_variant == 3 || item_variant == 4) &&
+			GetItemVariant(Wep_CritCola) == 4 &&
 			condition == TFCond_CritCola &&
+			time == 9.0 &&
 			TF2_GetPlayerClass(client) == TFClass_Scout
 		) {
-			// crit-a-cola normally applies 9 seconds, then relies on the energy drink meter to have it be 8 seconds
-			if (item_variant == 4 && time == 9.0) {
-				TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 6.0);
-				time = 6.0;
-				return Plugin_Changed;
-			}
-
-			TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 8.0);
-			return Plugin_Continue;
+			time = 6.0;
+			return Plugin_Changed;
 		}
 	}
 	return Plugin_Continue;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1734,14 +1734,14 @@ public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &pro
 		// crit-a-cola release variant duration modification
 		// also mark the user for death for pre-July2013 and release variants
 		// historically didn't have the Marked-for-Death symbol in HUD, but a visual cue is good
-		int variant = GetItemVariant(Wep_CritCola);
+		int item_variant = GetItemVariant(Wep_CritCola);
 		if (
-			(variant == 3 || variant == 4) &&
+			(item_variant == 3 || item_variant == 4) &&
 			condition == TFCond_CritCola &&
 			TF2_GetPlayerClass(client) == TFClass_Scout
 		) {
 			// crit-a-cola normally applies 9 seconds, then relies on the energy drink meter to have it be 8 seconds
-			if (variant == 4 && time == 9.0) {
+			if (item_variant == 4 && time == 9.0) {
 				TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 6.0);
 				time = 6.0;
 				return Plugin_Changed;

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -195,6 +195,10 @@
 	{
 		"fi"	"Krittikola"
 	}
+	"crocostyle"
+	{
+		"fi"	"Krokotyyli-pakkaus"
+	}
 	"dalokohsbar"
 	{
 		"fi"	"Suklaalevy"
@@ -231,6 +235,10 @@
 	{
 		"fi"	"Häätöilmoitus"
 	}
+	"expert"
+	{
+		"fi"	"Asiantuntijan taisteluvarusteet"
+	}
 	"fiststeel"
 	{
 		"fi"	"Teräsnyrkit"
@@ -238,6 +246,10 @@
 	"guillotine"
 	{
 		"fi"	"Lentävä giljotiini"
+	}
+	"gasjockey"
+	{
+		"fi"	"Bensapojan varusteet"
 	}
 	"glovesru"
 	{
@@ -250,6 +262,10 @@
 	"zatoichi"
 	{
 		"fi"	"Puolisokea samurai"
+	}
+	"hibernate"
+	{
+		"fi"	"Nukkuva karhu"
 	}
 	"liberty"
 	{
@@ -346,6 +362,10 @@
 	"solemn"
 	{
 		"fi"	"Vakava vala"
+	}
+	"spdelivery"
+	{
+		"fi"	"Erikoistoimitus"
 	}
 	"splendid"
 	{
@@ -459,7 +479,7 @@
 	}
 	"Bonk_PreJI"
 	{
-		"fi"	"Ennen Jungle Infernoa: ei hidasta tehosteen päätyttyä"
+		"fi"	"Ennen Jungle Infernoa: ei hidasta vaikutuksen päätyttyä"
 	}
 	"Booties_PreMYM"
 	{
@@ -475,7 +495,7 @@
 	}
 	"BuffaloSteak_PreMYM"
 	{
-		"fi"	"Ennen Meet your Matchiä: tehoste antaa +35%% nopeuslisän ja +10%% vahinkoalttiuden"
+		"fi"	"Ennen Meet your Matchiä: vaikutus antaa +35%% nopeuslisän ja +10%% vahinkoalttiuden"
 	}
 	"BuffaloSteak_Release"
 	{
@@ -485,7 +505,6 @@
 	{
 		"fi"	"Ennen 2013 kesää: +35%% nopeusbonus, vahinko otettu on minikriittisenä"
 	}
-	
 	"Targe_PreTB"
 	{
 		"fi"	"Ennen Tough Breakiä: 40%% räjähdyssietoa, jälkipolttoimmuniteetti, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
@@ -505,6 +524,26 @@
 	"CritCola_PreMYM"
 	{
 		"fi"	"Ennen Meet your Matchiä: +25%% nopeuslisä, +10%% vahinkoalttius, ei merkkaa kuolemaan hyökätessä"
+	}
+	"CritCola_PreJI"
+	{
+		"fi"	"Ennen Jungle Infernoa: +25%% nopeuslisä, +10%% vahinkoalttius, 2 sekunnin kuolemanmerkkaus vaikutuksen päättyessä"
+	}
+	"CritCola_PreDec2013"
+	{
+		"fi"	"Ennen Smissmas 2013: +25%% nopeuslisä, +25%% vahinkoalttius, ei merkkaa kuolemaan hyökätessä"
+	}
+	"CritCola_PreJuly2013"
+	{
+		"fi"	"Ennen 2013 kesää: +25%% nopeuslisä, vahinko otettu on minikriittisenä"
+	}
+	"CritCola_Release"
+	{
+		"fi"	"Julkaisuversio: vahinko otettu on minikriittisenä, vaikutus kestää 6 sekuntia"
+	}
+	"CrocoStyle_Release"
+	{
+		"fi"	"Palautettu esinejoukkoetu, ei kuolemaa pääosumista kun terveys yli 1. Varusta Nukutuskivääri, Darwinin vaarakilpi ja Puskanpätkijä saadaksesi edun."
 	}
 	"DalokohsBar_PreMYM"
 	{
@@ -566,6 +605,10 @@
 	{
 		"fi"	"Ennen Tough Breakiä: +50%% tulitusnopeus, ei laske terveyttä, ei aktiivista nopeusbonusta"
 	}
+	"Expert_Release"
+	{
+		"fi"	"Palautettu esinejoukkoetu, +10%% tulisieto. Varusta Lataus ja Laattaus sekä Ullapoolin tukki saadaksesi edun."
+	}
 	"FistSteel_PreJI"
 	{
 		"fi"	"Ennen Jungle Infernoa: ei parannusheikkouksia"
@@ -573,6 +616,10 @@
 	"Guillotine_PreJI"
 	{
 		"fi"	"Ennen Jungle Infernoa: kaukaiset osumat minikriittisiä (ei vähennä latausaikaa), kriittiset osumat tainnutettuihin"
+	}
+	"GasJockey_Release"
+	{
+		"fi"	"Palautettu esinejoukkoetu, +10%% nopeuslisä ja luotialttius. Varusta Rasvanpolttaja ja Tunkki saadaksesi edun."
 	}
 	"GlovesRU_PreTB"
 	{
@@ -589,6 +636,10 @@
 	"Zatoichi_PreTB"
 	{
 		"fi"	"Ennen Tough Breakiä: nopea vaihto, lyhyempi kantama, ei voi vaihtaa ellei tee tappoa, täysi parannus, satunnaiset kriittiset osumat"
+	}
+	"Hibernate_Release"
+	{
+		"fi"	"Palautettu esinejoukkoetu, +5%% kriittisen osuman sieto. Varusta Messinkipeto, Puhvelinpihvipurilainen ja Soturin sielu saadaksesi edun."
 	}
 	"Liberty_Release"
 	{
@@ -692,7 +743,7 @@
 	}
 	"Saharan_Release"
 	{
-		"fi"	"Palautettu esinejoukkoetu, hiljainen verhoistapoistuminen, 0,5s pidempi verhoutumisen välkkymisaika. Fantastista fetsiä ei tarvi"
+		"fi"	"Palautettu esinejoukkoetu, hiljainen verhoistapoistuminen, 0,5s pidempi verhoutumisen välkkymisaika. Varusta L'Etranger ja Ikuinen palkkiosi saadaksesi edun."
 	}
 	"Sandman_PreJI"
 	{
@@ -737,6 +788,10 @@
 	"Solemn_PreGM"
 	{
 		"fi"	"Ennen Gun Mettleä: ei tulitusnopeusheikkoutta"
+	}
+	"SpDelivery_Release"
+	{
+		"fi"	"Palautettu esinejoukkoetu, +25 maksimiterveys. Varusta Pysäyttäjä, Hullu maito ja Pyhä makrilli saadaksesi edun."
 	}
 	"Splendid_PreTB"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -529,11 +529,19 @@
 	}
 	"CritCola_PreJI"
 	{
-		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, 2 sec mark-for-death after effect ends"
+		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, 2 sec mark-for-death after buff expires"
 	}
 	"CritCola_PreDec2013"
 	{
 		"en"	"Reverted to pre-Smissmas 2013, +25%% movespeed, +25%% damage taken, no mark-for-death on attack"
+	}
+	"CritCola_PreJuly2013"
+	{
+		"en"	"Reverted to pre-Summer 2013, +25%% movespeed, damage taken mini-crits"
+	}
+	"CritCola_Release"
+	{
+		"en"	"Reverted to release, damage taken mini-crits, buff lasts 6 seconds"
 	}
 	"CrocoStyle_Release"
 	{
@@ -601,7 +609,7 @@
 	}
 	"Expert_Release"
 	{
-		"en"	"Restored release item set bonus. +10%% fire resist. Equip the Loch-n-Load and Ullapool Caber to gain the bonus, the hat is not required"
+		"en"	"Restored release item set bonus, +10%% fire resist. Equip the Loch-n-Load and Ullapool Caber to gain the bonus, the hat is not required"
 	}
 	"FistSteel_PreJI"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -527,6 +527,14 @@
 	{
 		"en"	"Reverted to pre-matchmaking, +25%% movespeed, +10%% damage taken, no mark-for-death on attack"
 	}
+	"CritCola_PreJI"
+	{
+		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, mark-for-death after effect ends"
+	}
+	"CritCola_PreDec2013"
+	{
+		"en"	"Reverted to pre-Smissmas 2013, +25%% movespeed, +25%% damage taken, no mark-for-death on attack"
+	}
 	"CrocoStyle_Release"
 	{
 		"en"	"Restored release item set bonus, no death from headshots when above 1 HP. Equip the Sydney Sleeper, DDS and Bushwacka to gain the bonus, the hat is not required"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -529,7 +529,7 @@
 	}
 	"CritCola_PreJI"
 	{
-		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, mark-for-death after effect ends"
+		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, 2 sec mark-for-death after effect ends"
 	}
 	"CritCola_PreDec2013"
 	{


### PR DESCRIPTION
### Summary of changes
Crit-a-Cola (pre-Jungle Inferno)
 - While under the effects,
 - +25% movement speed, your attacks mini-crit, and damage taken increased by 10%.
 - You are marked for death afterward for 2 seconds. 

Crit-a-Cola (pre-Smissmas 2013)
 - While under the effects,
 - +25% movement speed, your attacks mini-crit, and damage taken increased by 25%.

Crit-a-Cola (pre-Summer 2013)
 - While under the effects,
 - +25% movement speed and damage done and damage taken will be mini-crits.

Crit-a-Cola (release)
 - While under the effects, damage done and damage taken will be mini-crits.

also fix a sodapopper bug

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
N/A

### Other Info
N/A
