### PR TITLE
(Revert) Release Backburner Variant

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -403,6 +403,7 @@ public void OnPluginStart() {
 	ItemVariant(Wep_Axtinguisher, "Axtinguisher_PreTB");
 	ItemDefine("backburner", "Backburner_PreHat", CLASSFLAG_PYRO, Wep_Backburner);
 	ItemVariant(Wep_Backburner, "Backburner_119");
+	ItemVariant(Wep_Backburner, "Backburner_Release");
 	ItemDefine("basejump", "BaseJumper_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_DEMOMAN, Wep_BaseJumper);
 	ItemDefine("babyface", "BabyFace_PreGM", CLASSFLAG_SCOUT, Wep_BabyFace);
 	ItemVariant(Wep_BabyFace, "BabyFace_Release");
@@ -1831,11 +1832,20 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 40, 1146: { if (ItemIsEnabled(Wep_Backburner)) {
 			bool airblast = GetItemVariant(Wep_Backburner) == 0;
 			TF2Items_SetNumAttributes(itemNew, airblast ? 1 : 2);
-			if (airblast) {
-				TF2Items_SetAttribute(itemNew, 0, 2, 1.1); // 10% damage bonus
-			} else {
-				TF2Items_SetAttribute(itemNew, 0, 2, 1.2); // 20% damage bonus
-				TF2Items_SetAttribute(itemNew, 1, 356, 1.0); // no airblast
+			switch(GetItemVariant(Wep_Backburner)) 
+			{
+				case 0: 
+				{
+					TF2Items_SetAttribute(itemNew, 0, 2, 1.1); // 10% damage bonus; mult_dmg
+				}
+				case 1, 2: 
+				{
+					TF2Items_SetAttribute(itemNew, 0, 356, 1.0); // no airblast; airblast_disabled
+					if (GetItemVariant(Wep_Backburner == 1))
+						TF2Items_SetAttribute(itemNew, 1, 2, 1.2); // 20% damage bonus
+					else if (GetItemVariant(Wep_Backburner == 2))
+						TF2Items_SetAttribute(itemNew, 1, 26, 50.0); // +50 max health on wearer; add_maxhealth
+				}
 			}
 		}}
 		case 237: { if (GetItemVariant(Wep_RocketJumper) == 1) {
@@ -2490,6 +2500,12 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						) {
 							health_cur = GetClientHealth(attacker);
 							int pyro_overheal_max = 260; // this needs to be adjusted in case the backburner is reverted to the release version
+							if (GetItemVariant(Wep_Backburner) == 2) {
+								pyro_overheal_max = 335;
+								// 175 + 50 = 225 hp, then multiply for overheal: 225*1.5 = 337.5 hp. 
+								// According to the wiki, max overheal hp is found by rounding down to the nearest multiple of 5, so 335 max overheal	
+							}
+						
 							{
 								event1 = CreateEvent("player_healonhit", true);
 								SetEventInt(event1, "amount", intMin(pyro_overheal_max - health_cur, 75));

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1838,13 +1838,15 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				{
 					TF2Items_SetAttribute(itemNew, 0, 2, 1.1); // 10% damage bonus; mult_dmg
 				}
-				case 1, 2: 
+				case 1: 
 				{
-					TF2Items_SetAttribute(itemNew, 0, 356, 1.0); // no airblast; airblast_disabled
-					if (GetItemVariant(Wep_Backburner == 1))
-						TF2Items_SetAttribute(itemNew, 1, 2, 1.2); // 20% damage bonus
-					else if (GetItemVariant(Wep_Backburner == 2))
-						TF2Items_SetAttribute(itemNew, 1, 26, 50.0); // +50 max health on wearer; add_maxhealth
+					TF2Items_SetAttribute(itemNew, 0, 2, 1.2); // 20% damage bonus
+					TF2Items_SetAttribute(itemNew, 1, 356, 1.0); // no airblast; airblast_disabled
+				}
+				case 2:
+				{
+					TF2Items_SetAttribute(itemNew, 0, 26, 50.0); // +50 max health on wearer; add_maxhealth
+					TF2Items_SetAttribute(itemNew, 1, 356, 1.0); // no airblast; airblast_disabled
 				}
 			}
 		}}

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -459,6 +459,10 @@
 	{
 		"en"	"Reverted to 119th update, 20%% damage bonus, no airblast"
 	}
+	"Backburner_Release"
+	{
+		"en"	"Reverted to release, +50 max hp on wearer, no airblast"
+	}
 	"BaseJumper_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, can redeploy, more air control, while deployed float mid-air when on fire"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -453,11 +453,11 @@
 	}
 	"Backburner_PreHat"
 	{
-		"en"	"Reverted to Hatless update, 10%% damage bonus"
+		"en"	"Reverted to Hatless update, +10%% damage bonus"
 	}
 	"Backburner_119"
 	{
-		"en"	"Reverted to 119th update, 20%% damage bonus, no airblast"
+		"en"	"Reverted to 119th update, +20%% damage bonus, no airblast"
 	}
 	"Backburner_Release"
 	{


### PR DESCRIPTION
### Summary of changes
- **Release Backburner**
    - +50 max hp on wearer (225 hp, max overheal of 335 hp)
    - No airblast  

### Testing Attestation
- [X] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Itemtest, interaction with default reverted Powerjack also tested for every Backburner variant. Nothing breaks.
Tested damage values for each Backburner variant too. 

- On the first flame damage (damage value shown in HUD for the first flame particle that hits):
   - Vanilla: 13 dmg, airblasts
   - Variant 0 (prehat): 14 dmg, airblasts
   - Variant 1 (119th): 15 dmg, no airblast
   - Variant 2 (release): 13 dmg, no airblast, 335 max overheal with powerjack

### Other Info
This was probably way overdue now ever since someone requested this months ago. Might be a good idea to include this as a variant.
