### PR TITLE
(Reverts & Fix) Pre-Jungle Inferno and Pre-Tough Break Dead Ringer Variants + Revert Pomson cloak drain fix

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2199,7 +2199,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		}}
 		case 59: { if (ItemIsEnabled(Wep_DeadRinger)) {
 			bool preGunMettle = (GetItemVariant(Wep_DeadRinger) == 0);
-			TF2Items_SetNumAttributes(itemNew, preGunMettle ? 5 : 2);
+			TF2Items_SetNumAttributes(itemNew, preGunMettle ? 5 : 3);
 			if(preGunMettle) {
 				TF2Items_SetAttribute(itemNew, 0, 35, 1.8); // mult cloak meter regen rate
 				TF2Items_SetAttribute(itemNew, 1, 82, 1.6); // cloak consume rate increased
@@ -2210,6 +2210,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			else if (!preGunMettle) {
 				TF2Items_SetAttribute(itemNew, 0, 810, 0.0); // mod cloak no regen from items
 				TF2Items_SetAttribute(itemNew, 1, 728, 1.0); // NoCloakWhenCloaked
+				TF2Items_SetAttribute(itemNew, 2, 729, 0.35); // ReducedCloakFromAmmo
 			}
 		}}
 		case 44: { if (ItemIsEnabled(Wep_Sandman)) {
@@ -3265,8 +3266,7 @@ Action SDKHookCB_OnTakeDamage(
 						GetEntProp(weapon1, Prop_Send, "m_iItemDefinitionIndex") == 59
 					) {
 						if (
-							ItemIsEnabled(Wep_DeadRinger) && 
-							GetItemVariant(Wep_DeadRinger) == 0
+							ItemIsEnabled(Wep_DeadRinger) && GetItemVariant(Wep_DeadRinger) == 0
 						) {
 							cvar_ref_tf_feign_death_duration.FloatValue = 6.5;
 							cvar_ref_tf_feign_death_speed_duration.FloatValue = 6.5;
@@ -3281,7 +3281,9 @@ Action SDKHookCB_OnTakeDamage(
 							ResetConVar(cvar_ref_tf_feign_death_speed_duration);
 							cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.50;
 							ResetConVar(cvar_ref_tf_feign_death_damage_scale);							
-						} else {
+						} else if (
+							(GetItemVariant(Wep_DeadRinger) == -1 || GetItemVariant(Wep_DeadRinger) == 1) // just making sure
+						) {
 							ResetConVar(cvar_ref_tf_feign_death_duration);
 							ResetConVar(cvar_ref_tf_feign_death_speed_duration);
 							ResetConVar(cvar_ref_tf_feign_death_activate_damage_scale);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3865,9 +3865,9 @@ Action SDKHookCB_OnTakeDamage(
 										TF2_AddCondition(victim, TFCond_DeadRingered);
 											//PrintToChatAll("charge after hit (if): set to %f", charge);
 									}
-									// 70% cloak drain if hit with vanilla/pre-inferno/pre-tough break Dead Ringer by reverted Pomson from a distance greater than 512 HU
-									// Only causes 50% cloak drain at very far ranges due to Pomson fall-off even if reverted! Need to tackle this issue!
-									// Could probably use a linear equation instead? Where charge amount scales with damage1
+									// When distance is greater than 512 HU for vanilla/pre-inferno/pre-tough break Dead Ringer
+									// 70% cloak drain if hit by reverted Pomson
+									// At ranges near 1536 HU and beyond, drain cloak to 30% so it acts like 70% cloak drain on hit from any range
 									else if (
 										(GetItemVariant(Wep_DeadRinger) == -1 || GetItemVariant(Wep_DeadRinger) == 1 || GetItemVariant(Wep_DeadRinger) == 2) &&
 										damage1 >= 1 && 
@@ -3876,17 +3876,21 @@ Action SDKHookCB_OnTakeDamage(
 										players[victim].spy_is_feigning == false &&
 										!TF2_IsPlayerInCondition(victim, TFCond_DeadRingered)
 									) {
-										SetEntPropFloat(victim, Prop_Send, "m_flCloakMeter", 50.0);
-											//PrintToChatAll("charge after hit (else if): set to %f", charge);
-									}								
+										float charge_remap = 0.0;
+										charge_remap = ValveRemapVal(damage1, 1.0, 20.0, 50.0, 30.0);
+										SetEntPropFloat(victim, Prop_Send, "m_flCloakMeter", charge_remap);
+											//PrintToChatAll("charge after hit (else if): set to %f", charge_remap);
+									}
+									// When distance is greater than 512 HU
 									else {
 										SetEntPropFloat(victim, Prop_Send, "m_flCloakMeter", charge);
 											//PrintToChatAll("charge after hit (else): %f", charge);
 									}
 
 									// Bug fix to trigger Dead Ringer feign death for all variants from distances greater than 512 hammer units
+									// damage1 value is always 1.0 and greater if hit distance is more than 512 hammer units, and 20 if greater than 1536 HU
 									if (
-										damage1 > 0 && // damage1 value is always 1.0 and greater if hit distance is more than 512 hammer units
+										damage1 > 0 &&
 										GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&
 										players[victim].spy_is_feigning == false
 									) {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3268,6 +3268,7 @@ Action SDKHookCB_OnTakeDamage(
 						if (
 							ItemIsEnabled(Wep_DeadRinger) && GetItemVariant(Wep_DeadRinger) == 0
 						) {
+							// Pre-Gun Mettle Dead Ringer Stats
 							cvar_ref_tf_feign_death_duration.FloatValue = 6.5;
 							cvar_ref_tf_feign_death_speed_duration.FloatValue = 6.5;
 							cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.10;
@@ -3284,6 +3285,7 @@ Action SDKHookCB_OnTakeDamage(
 						} else if (
 							(GetItemVariant(Wep_DeadRinger) == -1 || GetItemVariant(Wep_DeadRinger) == 1) // just making sure
 						) {
+							// Pre-Inferno and Vanilla Dead Ringer Stat reset
 							ResetConVar(cvar_ref_tf_feign_death_duration);
 							ResetConVar(cvar_ref_tf_feign_death_speed_duration);
 							ResetConVar(cvar_ref_tf_feign_death_activate_damage_scale);
@@ -3861,9 +3863,11 @@ Action SDKHookCB_OnTakeDamage(
 										// When charge is less than 100.0, Spy loses 20% cloak. If charge is exactly 100.0 and the reverted DR is active, Spy loses 70% cloak.
 										SetEntPropFloat(victim, Prop_Send, "m_flCloakMeter", 99.99);
 										TF2_AddCondition(victim, TFCond_DeadRingered);
-											//PrintToChatAll("charge after hit (if): %f", charge);
+											//PrintToChatAll("charge after hit (if): set to %f", charge);
 									}
 									// 70% cloak drain if hit with vanilla/pre-inferno/pre-tough break Dead Ringer by reverted Pomson from a distance greater than 512 HU
+									// Only causes 50% cloak drain at very far ranges due to Pomson fall-off even if reverted! Need to tackle this issue!
+									// Could probably use a linear equation instead? Where charge amount scales with damage1
 									else if (
 										(GetItemVariant(Wep_DeadRinger) == -1 || GetItemVariant(Wep_DeadRinger) == 1 || GetItemVariant(Wep_DeadRinger) == 2) &&
 										damage1 >= 1 && 
@@ -3873,15 +3877,14 @@ Action SDKHookCB_OnTakeDamage(
 										!TF2_IsPlayerInCondition(victim, TFCond_DeadRingered)
 									) {
 										SetEntPropFloat(victim, Prop_Send, "m_flCloakMeter", 50.0);
-											//PrintToChatAll("charge after hit (else if): set to 50", charge);
+											//PrintToChatAll("charge after hit (else if): set to %f", charge);
 									}								
 									else {
 										SetEntPropFloat(victim, Prop_Send, "m_flCloakMeter", charge);
 											//PrintToChatAll("charge after hit (else): %f", charge);
 									}
 
-									// Bug fix to trigger Dead Ringer feign death from distances greater than 512 hammer units
-									// is this for any dead ringer version vs. reverted pomson?
+									// Bug fix to trigger Dead Ringer feign death for all variants from distances greater than 512 hammer units
 									if (
 										damage1 > 0 && // damage1 value is always 1.0 and greater if hit distance is more than 512 hammer units
 										GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1263,8 +1263,8 @@ public void OnGameFrame() {
 
 				if (TF2_GetPlayerClass(idx) == TFClass_Spy) {
 					
-					if (GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) {
-						// dead ringer cloak meter mechanics
+					if (GetItemVariant(Wep_DeadRinger) == 0) {
+						// pre-gun mettle dead ringer cloak meter mechanics
 
 						if (players[idx].spy_is_feigning == false) {
 							if (TF2_IsPlayerInCondition(idx, TFCond_DeadRingered)) {
@@ -1315,8 +1315,8 @@ public void OnGameFrame() {
 						players[idx].spy_cloak_meter = cloak;
 					}
 
-					if(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) {
-						// deadringer cancel condition when feign buff ends
+					if(GetItemVariant(Wep_DeadRinger) == 0) {
+						// pre-gun mettle deadringer cancel condition when feign buff ends
 						if (
 							ItemIsEnabled(Wep_DeadRinger) &&
 							players[idx].spy_is_feigning &&
@@ -1613,10 +1613,10 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 	}
 
 	{
-		// dead ringer stuff
+		// pre-gun mettle dead ringer stuff
 
 		if (
-			(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) &&
+			(GetItemVariant(Wep_DeadRinger) == 0) &&
 			ItemIsEnabled(Wep_DeadRinger) &&
 			TF2_GetPlayerClass(client) == TFClass_Spy
 		) {
@@ -1733,10 +1733,10 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 
 public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &provider) {
 	{
-		// prevent speed boost being applied on feign death
+		// pre-gun mettle dead ringer prevent speed boost being applied on feign death
 		if (
 			ItemIsEnabled(Wep_DeadRinger) &&
-			(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) &&
+			(GetItemVariant(Wep_DeadRinger) == 0) &&
 			condition == TFCond_SpeedBuffAlly &&
 			TF2_GetPlayerClass(client) == TFClass_Spy &&
 			players[client].ticks_since_feign_ready == GetGameTickCount()
@@ -2198,10 +2198,9 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 2, 547, 1.0); // This weapon deploys 0% faster
 		}}
 		case 59: { if (ItemIsEnabled(Wep_DeadRinger)) {
-			bool preGunMettle = (GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2); 
-			// i'm making it != 1 || !=2 to make it easier adding in other pre-GM DR variants
+			bool preGunMettle = (GetItemVariant(Wep_DeadRinger) == 0);
+			TF2Items_SetNumAttributes(itemNew, preGunMettle ? 5 : 2);
 			if(preGunMettle) {
-				TF2Items_SetNumAttributes(itemNew, 5);
 				TF2Items_SetAttribute(itemNew, 0, 35, 1.8); // mult cloak meter regen rate
 				TF2Items_SetAttribute(itemNew, 1, 82, 1.6); // cloak consume rate increased
 				TF2Items_SetAttribute(itemNew, 2, 83, 1.0); // cloak consume rate decreased
@@ -2209,7 +2208,6 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				TF2Items_SetAttribute(itemNew, 4, 810, 0.0); // mod cloak no regen from items
 			}
 			else if (!preGunMettle) {
-				TF2Items_SetNumAttributes(itemNew, 2);
 				TF2Items_SetAttribute(itemNew, 0, 810, 0.0); // mod cloak no regen from items
 				TF2Items_SetAttribute(itemNew, 1, 728, 1.0); // NoCloakWhenCloaked
 			}
@@ -3268,7 +3266,7 @@ Action SDKHookCB_OnTakeDamage(
 					) {
 						if (
 							ItemIsEnabled(Wep_DeadRinger) && 
-							(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2)
+							GetItemVariant(Wep_DeadRinger) == 0
 						) {
 							cvar_ref_tf_feign_death_duration.FloatValue = 6.5;
 							cvar_ref_tf_feign_death_speed_duration.FloatValue = 6.5;
@@ -3279,7 +3277,10 @@ Action SDKHookCB_OnTakeDamage(
 							ItemIsEnabled(Wep_DeadRinger) && GetItemVariant(Wep_DeadRinger) == 2
 						) {
 							// Pre-Tough Break Dead Ringer Initial Damage Resist Stat
+							ResetConVar(cvar_ref_tf_feign_death_duration);
+							ResetConVar(cvar_ref_tf_feign_death_speed_duration);
 							cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.50;
+							ResetConVar(cvar_ref_tf_feign_death_damage_scale);							
 						} else {
 							ResetConVar(cvar_ref_tf_feign_death_duration);
 							ResetConVar(cvar_ref_tf_feign_death_speed_duration);
@@ -3289,10 +3290,9 @@ Action SDKHookCB_OnTakeDamage(
 					}
 				}
 
-				// dead ringer track when feign begins
+				// pre-gun mettle dead ringer track when feign begins
 				if (
-					ItemIsEnabled(Wep_DeadRinger) && 
-					(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2)
+					ItemIsEnabled(Wep_DeadRinger) && GetItemVariant(Wep_DeadRinger) == 0
 				) {
 					if (
 						GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&
@@ -3843,12 +3843,12 @@ Action SDKHookCB_OnTakeDamage(
 									charge = (charge < 0.0 ? 0.0 : charge);
 										//PrintToChatAll("charge final: %f", charge);
 									
-									// Bug fix for reverted Dead Ringer losing 70% cloak when hit by Pomson at close range
+									// Bug fix for reverted pre-gun mettle Dead Ringer losing 70% cloak when hit by Pomson at close range
 									// Prevents 70% cloak getting drained when distance is less than 512 HU.
 									// Drain only 20% cloak from distances less than 512 hammer units on feign
 									if (
 										ItemIsEnabled(Wep_DeadRinger) && 
-										(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) &&
+										GetItemVariant(Wep_DeadRinger) == 0 &&
 										damage1 == 0 && 
 										charge == 100 && 
 										GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&
@@ -3861,9 +3861,9 @@ Action SDKHookCB_OnTakeDamage(
 										TF2_AddCondition(victim, TFCond_DeadRingered);
 											//PrintToChatAll("charge after hit (if): %f", charge);
 									}
-									// 70% cloak drain if hit with unreverted/pre-inferno Dead Ringer by reverted Pomson from a distance greater than 512 HU
+									// 70% cloak drain if hit with vanilla/pre-inferno/pre-tough break Dead Ringer by reverted Pomson from a distance greater than 512 HU
 									else if (
-										(GetItemVariant(Wep_DeadRinger) <= -1 || GetItemVariant(Wep_DeadRinger) == 1) &&
+										(GetItemVariant(Wep_DeadRinger) == -1 || GetItemVariant(Wep_DeadRinger) == 1 || GetItemVariant(Wep_DeadRinger) == 2) &&
 										damage1 >= 1 && 
 										charge < 100 && 
 										GetEntProp(victim, Prop_Send, "m_bFeignDeathReady") &&
@@ -3891,8 +3891,8 @@ Action SDKHookCB_OnTakeDamage(
 							}
 						}
 
-						if(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) {
-							// When Pomson revert is turned off and pre-GM Dead Ringer revert is turned on, prevent 70% cloak drain on hit at any distance
+						if(GetItemVariant(Wep_DeadRinger) == 0) {
+							// When Pomson revert is turned off and pre-gun mettle Dead Ringer revert is turned on, prevent 70% cloak drain on hit at any distance
 							if (
 								ItemIsEnabled(Wep_DeadRinger) && !ItemIsEnabled(Wep_Pomson) &&
 								StrEqual(class, "tf_weapon_drg_pomson") &&
@@ -3997,12 +3997,12 @@ void SDKHookCB_OnTakeDamagePost(
 	int weapon, float damage_force[3], float damage_position[3], int damage_custom
 ) {
 	if (
-		(GetItemVariant(Wep_DeadRinger) != 1 || GetItemVariant(Wep_DeadRinger) != 2) &&
+		(GetItemVariant(Wep_DeadRinger) == 0) &&
 		victim >= 1 &&
 		victim <= MaxClients &&
 		TF2_GetPlayerClass(victim) == TFClass_Spy
 	) {
-		// dead ringer damage tracking
+		// pre-gun mettle dead ringer damage tracking
 		if (TF2_IsPlayerInCondition(victim, TFCond_DeadRingered)) {
 			players[victim].damage_taken_during_feign += damage;
 		}

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -569,11 +569,11 @@
 	}
 	"Ringer_PreJI"
 	{
-		"en"	"Reverted to pre-inferno, same modern stats but can pick up ammo to regenerate while uncloaked"
+		"en"	"Reverted to pre-inferno, same modern stats but can pick up ammo while uncloaked, -35%% less cloak from ammo boxes"
 	}
 	"Ringer_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, same modern stats but 50%% initial dmg resist, can pick up ammo to regenerate while uncloaked"
+		"en"	"Reverted to pre-toughbreak, same modern stats but 50%% initial dmg resist, can pick up ammo while uncloaked, -35%% less cloak from ammo boxes"
 	}
 	"Degreaser_PreTB"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -571,6 +571,10 @@
 	{
 		"en"	"Reverted to pre-inferno, same modern stats but can pick up ammo to regenerate while uncloaked"
 	}
+	"Ringer_PreTB"
+	{
+		"en"	"Reverted to pre-toughbreak, same modern stats but 50%% initial dmg resist, can pick up ammo to regenerate while uncloaked"
+	}
 	"Degreaser_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, 65%% faster weapon switch, -10%% dmg & -25%% afterburn dmg penalties"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -567,6 +567,10 @@
 	{
 		"en"	"Reverted to pre-gunmettle, can pick up ammo, 90%% dmg resist for up to 6.5s (reduced by dmg taken)"
 	}
+	"Ringer_PreJI"
+	{
+		"en"	"Reverted to pre-inferno, same modern stats but can pick up ammo to regenerate while uncloaked"
+	}
 	"Degreaser_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, 65%% faster weapon switch, -10%% dmg & -25%% afterburn dmg penalties"


### PR DESCRIPTION
### Summary of changes
* Added Pre-Jungle Inferno & Pre-Tough Break Dead Ringer variants
* Fixed incorrect cloak drain for reverted Pomson with vanilla, pre-inferno, and pre-tough break Dead Ringer versions.
    * Cloak drain would not become 30% at far ranges beyond 512 HU, so this was fixed by using ValveRemapVal. This should be a good enough solution.

### Testing Attestation
- [x] - This change has been tested by me
- [ ] - This change has been tested by others

### Description of testing
Seems to work without issues with default pre-GM Dead Ringer. It'd be nice for others to test this just in case there are any serious bugs.

### Other Info
* **The Dead Ringer (Pre-Jungle Inferno)**
    * Same stats as modern Dead Ringer
    * Can regenerate cloak with ammo packs only if uncloaked
    * -35% less cloak from ammo packs
* **The Dead Ringer (Pre-Tough Break)**
    * Same stats as modern Dead Ringer
    * Can regenerate cloak with ammo packs only if uncloaked
    * -35% less cloak from ammo packs
    * 50% initial damage resistance on feign (instead of 75%)

As for why I included pre-Tough Break Dead Ringer, it's because a lot of people complain about the Dead Ringer being too overpowered. Here's their option if ever they find it too annoying if they still want to revert the Dead Ringer.