### PR TITLE
Add pre-toughbreak weapon switch time cvar, with various fixes

### DIFF
--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -60,7 +60,7 @@ sm_reverts__item_rescueranger 1
 sm_reverts__item_reserve 1
 sm_reverts__item_bison 1
 sm_reverts__item_rocketjmp 1
-sm_reverts__item_saharan 1
+sm_reverts__item_saharan 2
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 1

--- a/cfg/reverts_disable_all.cfg
+++ b/cfg/reverts_disable_all.cfg
@@ -2,6 +2,7 @@
 // Disables all weapon reverts in a complete list
 
 sm_reverts__enable_dropped_weapon 0
+sm_reverts__pre_toughbreak_switch 0
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 0
 sm_reverts__item_miniramp 0

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -61,7 +61,7 @@ sm_reverts__item_rescueranger 1
 sm_reverts__item_reserve 1
 sm_reverts__item_bison 1
 sm_reverts__item_rocketjmp 2
-sm_reverts__item_saharan 1
+sm_reverts__item_saharan 2
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
 // release scottish resistance was just awful to use

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -34,7 +34,7 @@ sm_reverts__item_enforcer 2
 sm_reverts__item_equalizer 3
 sm_reverts__item_eviction 2
 sm_reverts__item_expert 1
-sm_reverts__item_fiststeel 1
+sm_reverts__item_fiststeel 3
 sm_reverts__item_guillotine 1
 sm_reverts__item_gasjockey 1
 // Note: gas jockey set is enabled. note that the speed bonus can stack with the powerjack revert used here.

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -8,6 +8,7 @@
 
 
 sm_reverts__enable_dropped_weapon 1
+sm_reverts__pre_toughbreak_switch 1
 sm_reverts__item_airblast 1
 // note: airblast revert is not 100% accurate due to different hitboxes
 sm_reverts__item_airstrike 0
@@ -45,8 +46,8 @@ sm_reverts__item_disciplinary 1
 sm_reverts__item_dragonfury 1
 sm_reverts__item_enforcer 1
 sm_reverts__item_equalizer 0
-sm_reverts__item_eviction 0
-// eviction lacks pre-GM version (no 3 sec speed boost on hit)
+sm_reverts__item_eviction 2
+// eviction lacks pre-GM version (no 3 sec speed boost on hit), this is the closest version
 sm_reverts__item_expert 0
 sm_reverts__item_fiststeel 2
 sm_reverts__item_guillotine 1

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2246,9 +2246,8 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			}	
 		}}
 		case 230: { if (ItemIsEnabled(Wep_SydneySleeper)) {
-			TF2Items_SetNumAttributes(itemNew, 2);
-			TF2Items_SetAttribute(itemNew, 0, 42, 0.0); // sniper no headshots
-			TF2Items_SetAttribute(itemNew, 1, 175, 0.0); // jarate duration
+			TF2Items_SetNumAttributes(itemNew, 1);
+			TF2Items_SetAttribute(itemNew, 0, 175, 0.0); // jarate duration
 		}}
 		case 448: { if (ItemIsEnabled(Wep_SodaPopper)) {
 			bool minicrits = GetItemVariant(Wep_SodaPopper) == 0;
@@ -2559,31 +2558,6 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 									SetEntityHealth(attacker, health_cur);
 								}
 							}
-						}
-					}
-				}
-			}
-
-			{
-				// fix sydney sleeper headshot kill icon (unless crit-boosted)
-
-				if (
-					GetEventInt(event, "customkill") == TF_CUSTOM_HEADSHOT &&
-					players[attacker].headshot_frame == GetGameTickCount() &&
-					PlayerIsCritboosted(attacker) == false
-				) {
-					weapon = GetEntPropEnt(attacker, Prop_Send, "m_hActiveWeapon");
-
-					if (weapon > 0) {
-						GetEntityClassname(weapon, class, sizeof(class));
-
-						if (
-							ItemIsEnabled(Wep_SydneySleeper) &&
-							StrEqual(class, "tf_weapon_sniperrifle") &&
-							GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 230
-						) {
-							SetEventInt(event, "customkill", TF_DMG_CUSTOM_NONE);
-							return Plugin_Changed;
 						}
 					}
 				}
@@ -3612,16 +3586,6 @@ Action SDKHookCB_OnTakeDamage(
 							players[attacker].sleeper_piss_explode = true;
 						}
 					}
-
-					// disable headshot crits
-					// ...is this even needed?
-					if (
-						damage_type & DMG_CRIT != 0 &&
-						PlayerIsCritboosted(attacker) == false
-					) {
-						damage_type = (damage_type & ~DMG_CRIT);
-						return Plugin_Changed;
-					}
 				}
 			}
 
@@ -4185,6 +4149,7 @@ bool PlayerIsInvulnerable(int client) {
 	);
 }
 
+/*
 TFCond critboosts[] =
 {
 	TFCond_Kritzkrieged,
@@ -4208,6 +4173,7 @@ bool PlayerIsCritboosted(int client) {
 
 	return false;
 }
+*/
 
 float ValveRemapVal(float val, float a, float b, float c, float d) {
 	// https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/public/mathlib/mathlib.h#L648

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -50,7 +50,7 @@
 
 #define PLUGIN_NAME "TF2 Weapon Reverts"
 #define PLUGIN_DESC "Reverts nerfed weapons back to their glory days"
-#define PLUGIN_AUTHOR "Bakugo, NotnHeavy, random, huutti, VerdiusArcana, MindfulProtons"
+#define PLUGIN_AUTHOR "Bakugo, NotnHeavy, random, huutti, VerdiusArcana, MindfulProtons, EricZhang456"
 
 #define PLUGIN_VERSION_NUM "2.0.0"
 // Add a OS suffix if Memorypatch reverts are used

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2230,21 +2230,18 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			switch (GetItemVariant(Wep_Shortstop)) {
 				case 0, 1: {
 					// Pre-Manniversary Shortstop
-					TF2Items_SetNumAttributes(itemNew, 5);
-					TF2Items_SetAttribute(itemNew, 0, 76, 1.125); // 12.5% max primary ammo on wearer, reverts max ammo back to 36, required for ammo sharing to work
-					TF2Items_SetAttribute(itemNew, 1, 241, 1.0); // reload time increased hidden
-					TF2Items_SetAttribute(itemNew, 2, 534, 1.00); // airblast vulnerability multiplier hidden
-					TF2Items_SetAttribute(itemNew, 3, 535, 1.00); // damage force increase hidden
-					TF2Items_SetAttribute(itemNew, 4, 536, 1.00); // damage force increase text
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 241, 1.0); // reload time increased hidden
+					TF2Items_SetAttribute(itemNew, 1, 534, 1.00); // airblast vulnerability multiplier hidden
+					TF2Items_SetAttribute(itemNew, 2, 535, 1.00); // damage force increase hidden
 				}
 				case 2, 3: {
 					// Pre-Gun Mettle Shortstop
-					TF2Items_SetNumAttributes(itemNew, 6);
-					TF2Items_SetAttribute(itemNew, 1, 526, 1.20); // 20% bonus healing from all sources
-					TF2Items_SetAttribute(itemNew, 2, 534, 1.40); // airblast vulnerability multiplier hidden
-					TF2Items_SetAttribute(itemNew, 3, 535, 1.40); // damage force increase hidden
-					TF2Items_SetAttribute(itemNew, 4, 536, 1.40); // damage force increase text
-					TF2Items_SetAttribute(itemNew, 5, 128, 0.0); // disable provide_on_active so push force penalty is active at all times
+					TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetAttribute(itemNew, 0, 526, 1.20); // 20% bonus healing from all sources
+					TF2Items_SetAttribute(itemNew, 1, 534, 1.40); // airblast vulnerability multiplier hidden
+					TF2Items_SetAttribute(itemNew, 2, 535, 1.40); // damage force increase hidden
+					TF2Items_SetAttribute(itemNew, 3, 128, 0.0); // disable provide_on_active so push force penalty is active at all times
 				}
 			}	
 		}}


### PR DESCRIPTION
### Summary of changes
apply 34% longer weapon switch attribute when enabled

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
N/A

### Other Info
also change configs and some minor fixes
