### PR TITLE
Add piercing attribute to Bison and Pomson to imitate "Untyped" damage type + More historically accurate Bison variant

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3873,7 +3873,7 @@ Action SDKHookCB_OnTakeDamage(
 									damage_type = DMG_PREVENT_PHYSICS_FORCE + DMG_CRIT; // Add back crit damage if the shot is a crit
 								*/
 
-								damage = 16.00 * ValveRemapVal(floatMin(0.35, GetGameTime() - entities[players[victim].projectile_touch_entity].spawn_timestamp), 0.35 / 2, 0.35, 1.25, 0.75); // Deal 16 base damage with 125% rampup, 75% falloff.
+								damage = 16.00 * ValveRemapVal(floatMin(0.35, GetGameTime() - entities[players[victim].projectile_touch_entity].spawn_time), 0.35 / 2, 0.35, 1.25, 0.75); // Deal 16 base damage with 125% rampup, 75% falloff.
 
 								return Plugin_Changed;
 							}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -182,7 +182,6 @@ enum struct Entity {
 	bool exists;
 	float spawn_time;
 	bool is_demo_shield;
-	float spawn_timestamp;
 }
 
 ConVar cvar_enable;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -182,6 +182,7 @@ enum struct Entity {
 	bool exists;
 	float spawn_time;
 	bool is_demo_shield;
+	float spawn_timestamp;
 }
 
 ConVar cvar_enable;
@@ -496,6 +497,7 @@ public void OnPluginStart() {
 	ItemDefine("reserve", "Reserve_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_PYRO, Wep_ReserveShooter);
 	ItemVariant(Wep_ReserveShooter, "Reserve_PreJI");
 	ItemDefine("bison", "Bison_PreMYM", CLASSFLAG_SOLDIER, Wep_Bison);
+	ItemVariant(Wep_Bison, "Bison_PreMYM_Historical");
 	ItemDefine("rocketjmp", "RocketJmp_Pre2013", CLASSFLAG_SOLDIER, Wep_RocketJumper);
 	ItemVariant(Wep_RocketJumper, "RocketJmp_Pre2013_Intel");
 	ItemDefine("saharan", "Saharan_Release", CLASSFLAG_SPY, Set_Saharan);
@@ -1501,6 +1503,8 @@ public void OnEntityCreated(int entity, const char[] class) {
 		return;
 	}
 
+	entities[entity].spawn_timestamp = GetGameTime(); // for bison/pomson damage numbers handling
+
 	entities[entity].exists = true;
 	entities[entity].spawn_time = 0.0;
 	entities[entity].is_demo_shield = false;
@@ -2105,9 +2109,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				TF2Items_SetAttribute(itemNew, 0, 16, 7.0); // On Hit: Gain up to +7 health
 			}
 		}}
-		case 588: { if (ItemIsEnabled(Wep_Pomson) && GetItemVariant(Wep_Pomson) == 1) {
-			TF2Items_SetNumAttributes(itemNew, 1);
-			TF2Items_SetAttribute(itemNew, 0, 283, 1.0); // energy_weapon_penetration; NOTE: turns pomson projectile into bison projectile
+		case 588: { if (ItemIsEnabled(Wep_Pomson)) {
+			bool release = GetItemVariant(Wep_Pomson) == 1;
+			TF2Items_SetNumAttributes(itemNew, release ? 2 : 1);
+			TF2Items_SetAttribute(itemNew, 0, 797, 1.0); // mod_pierce_resists_absorbs; pierce resistances so it acts like untyped damage
+			if (release)
+				TF2Items_SetAttribute(itemNew, 1, 283, 1.0); // energy_weapon_penetration; NOTE: turns pomson projectile into bison projectile
 		}}		
 		case 214: { if (ItemIsEnabled(Wep_Powerjack)) {
 			// health bonus with overheal for all variants handled elsewhere
@@ -2179,6 +2186,10 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 1, 178, 0.85); // 15% faster weapon switch
 			TF2Items_SetAttribute(itemNew, 2, 547, 1.0); // This weapon deploys 0% faster
 		}}
+		case 442: { if (ItemIsEnabled(Wep_Bison)) {
+			TF2Items_SetNumAttributes(itemNew, 1);
+			TF2Items_SetAttribute(itemNew, 0, 797, 1.0); // mod_pierce_resists_absorbs; pierce resistances so it acts like untyped damage
+		}}			
 		case 59: { if (ItemIsEnabled(Wep_DeadRinger)) {
 			bool preGunMettle = (GetItemVariant(Wep_DeadRinger) == 0);
 			TF2Items_SetNumAttributes(itemNew, preGunMettle ? 5 : 3);
@@ -3847,6 +3858,28 @@ Action SDKHookCB_OnTakeDamage(
 									}								
 								}
 							}
+
+							// Historically accurate Pre-MyM Bison damage numbers against players ported from NotnHeavy's pre-GM plugin
+							// Using this code does not work with the Pomson for some reason. I do not know why.
+							if (
+								(StrEqual(class, "tf_weapon_raygun") && GetItemVariant(Wep_Bison) == 1)
+							) {
+								damage_type ^= DMG_USEDISTANCEMOD; // Do not use internal rampup/falloff.
+								
+								// Use piercing attribute instead which ignores damage resistances and does not ignore vulnerabilities just like untyped damage
+								// I am leaving this in just in case. If you want to test how "Untyped" damage type works, use the vanilla Flying Guillotine - the first hit and Bleed are "Untyped" damage types.
+								/*
+								// Ignore vaccinator resistance by changing damage types
+								if (damage_type & DMG_CRIT == 0)
+									damage_type = DMG_PREVENT_PHYSICS_FORCE; 
+								else if (damage_type & DMG_CRIT != 0)
+									damage_type = DMG_PREVENT_PHYSICS_FORCE + DMG_CRIT; // Add back crit damage if the shot is a crit
+								*/
+
+								damage = 16.00 * ValveRemapVal(floatMin(0.35, GetGameTime() - entities[players[victim].projectile_touch_entity].spawn_timestamp), 0.35 / 2, 0.35, 1.25, 0.75); // Deal 16 base damage with 125% rampup, 75% falloff.
+
+								return Plugin_Changed;
+							}
 						}
 
 						if(GetItemVariant(Wep_DeadRinger) == 0) {
@@ -5129,6 +5162,18 @@ MRESReturn DHookCallback_CTFPlayer_AddToSpyKnife(int entity, DHookReturn returnV
  * @return		The smaller integer between x and y.
  */
 int intMin(int x, int y)
+{
+	return x > y ? y : x;
+}
+
+/**
+ * Get the smaller float between two floats.
+ * 
+ * @param x		Float x.
+ * @param y		Float y.
+ * @return		The smaller float between x and y.
+ */
+float floatMin(float x, float y)
 {
 	return x > y ? y : x;
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1502,8 +1502,6 @@ public void OnEntityCreated(int entity, const char[] class) {
 		return;
 	}
 
-	entities[entity].spawn_timestamp = GetGameTime(); // for bison/pomson damage numbers handling
-
 	entities[entity].exists = true;
 	entities[entity].spawn_time = 0.0;
 	entities[entity].is_demo_shield = false;

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -705,15 +705,15 @@
 	}
 	"Pomson_PreGM"
 	{
-		"en"	"Increased hitbox size (same as Bison), passes through team, no uber & cloak drain fall-off, lights up friendly Huntsman arrows"
+		"en"	"Increased hitbox size (same as Bison), passes through team, no uber & cloak drain fall-off, lights up friendly Huntsman arrows, ignores dmg resists"
 	}
 	"Pomson_Release"
 	{
-		"en"	"Reverted to release, same dmg as Bison, bigger hitbox size, passes thru players, no uber & cloak drain fall-off, lights up friendly Huntsman arrows"
+		"en"	"Reverted to release, same dmg as Bison, bigger hitbox size, passes thru players, no uber & cloak drain fall-off, lights up friendly Huntsman arrows, ignores dmg resists"
 	}
 	"Pomson_PreGM_Historical"
 	{
-		"en"	"Reverted to pre-gunmettle, increased hitbox size (same as Bison), does not pass through team, no uber & cloak drain fall-off, lights up friendly Huntsman arrows"
+		"en"	"Reverted to pre-gunmettle, increased hitbox size (same as Bison), does not pass through team, no uber & cloak drain fall-off, lights up friendly Huntsman arrows, ignores dmg resists"
 	}	
 	"Powerjack_PreGM"
 	{
@@ -765,7 +765,11 @@
 	}
 	"Bison_PreMYM"
 	{
-		"en"	"Reverted to pre-matchmaking, increased hitbox size, can hit the same player more times, lights up friendly Huntsman arrows"
+		"en"	"Reverted to pre-matchmaking, increased hitbox size, can hit the same player more times, lights up friendly Huntsman arrows, ignores dmg resists"
+	}
+	"Bison_PreMYM_Historical"
+	{
+		"en"	"Reverted to pre-matchmaking, increased hitbox size, can hit the same player more times, lights up friendly Huntsman arrows, ignores dmg resists, old dmg falloff"
 	}
 	"RocketJmp_Pre2013"
 	{


### PR DESCRIPTION
### Summary of changes
Applies the Enforcer's damage piercing attribute to all Bison and Pomson variants to imitate "Untyped" damage type. It should ignore damage resistances while not ignoring damage vulnerabilities. This should allow the Bison and Pomson to ignore Vaccinator resistances, which used to be one of its counters.

If you want to test how Untyped damage works, use the vanilla Flying Guillotine and test it on a Fists of Steel heavy. The first hit and the Bleed damages are both Untyped damage types (according to the wiki, anyways)

This also adds a more historically accurate Bison variant that uses the old damage numbers and fall-off mechanics ported from NotnHeavy's pre-GM plugin. Basically it does 20 damage at close range, then falls off to 12 dmg or so.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Itemtest with bots

### Other Info
Should be good to go.

If you're wondering why I didn't make the Pomson have old damage falloff and numbers, apparently it doesn't work if I use the code for the Bison? I am not sure why. That's why I'm just making the other Bison variant only have the old damage mechanics.