### PR TITLE
(i18n) Add names of translators in localization files

### DIFF
--- a/translations/chi/reverts.phrases.txt
+++ b/translations/chi/reverts.phrases.txt
@@ -1,3 +1,6 @@
+// Simplified Chinese translation done by:
+// Eric Zhang	https://steamcommunity.com/id/ericzhang456/
+
 "Phrases"
 {
 	// class names

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -1,3 +1,6 @@
+// Finnish translation done by:
+// huutti	https://steamcommunity.com/id/reactos/
+
 "Phrases"
 {
 	// class names

--- a/translations/fr/reverts.phrases.txt
+++ b/translations/fr/reverts.phrases.txt
@@ -1,3 +1,6 @@
+// French translation done by:
+// Brolunite	https://steamcommunity.com/id/brolunite/
+
 "Phrases"
 {
 	// class names

--- a/translations/pl/reverts.phrases.txt
+++ b/translations/pl/reverts.phrases.txt
@@ -1,3 +1,6 @@
+// Polish translation done by:
+// Employedcamel	https://steamcommunity.com/id/djhazel/
+
 "Phrases"
 {
 	// class names


### PR DESCRIPTION
### Summary of changes
Add names of translators in localization files. Will do the same to the Wiki too, allows for easy contact and traceability.

### Testing Attestation
- [ ] - This change has been tested
- [X] - This change has not been tested, reasoning below

### Description of testing
just added comments

### Other Info
See [wiki page here](https://github.com/rsedxcftvgyhbujnkiqwe/castaway-plugins/wiki/Localization-Translation-Credits)
