### PR TITLE
(Reverts) Pomson fixes part 2

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1624,7 +1624,6 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 					players[client].feign_ready_tick > 0
 				) {
 					// undo 50% drain on activated
-					// add 50% meter to compensate for pomson drain
 					SetEntPropFloat(client, Prop_Send, "m_flCloakMeter", cloak + 50.0);
 				}
 			}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -176,7 +176,6 @@ enum struct Player {
 	int fall_dmg_tick;
 	int ticks_since_switch;
 	bool player_jumped;
-	int pomson_hit_tick;
 }
 
 enum struct Entity {
@@ -1575,7 +1574,7 @@ public void OnEntityDestroyed(int entity) {
 }
 
 public void TF2_OnConditionAdded(int client, TFCond condition) {
-	//float cloak;
+	float cloak;
 
 	// this function is called on a per-frame basis
 	// if two conds are added within the same game frame,
@@ -1614,21 +1613,15 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 			TF2_GetPlayerClass(client) == TFClass_Spy
 		) {
 			if (condition == TFCond_DeadRingered) {
-				//cloak = GetEntPropFloat(client, Prop_Send, "m_flCloakMeter");
+				cloak = GetEntPropFloat(client, Prop_Send, "m_flCloakMeter");
 
 				if (
 					abs(GetGameTickCount() - players[client].feign_ready_tick) <= 2 &&
 					players[client].feign_ready_tick > 0
 				) {
 					// undo 50% drain on activated
-					float meter = 100.0;
-					if (
-						abs(GetGameTickCount() - players[client].pomson_hit_tick) <= 2 &&
-						players[client].pomson_hit_tick > 0
-					) {
-						meter = 80.0;
-					}
-					SetEntPropFloat(client, Prop_Send, "m_flCloakMeter", meter);
+					// add 50% meter to compensate for pomson drain
+					SetEntPropFloat(client, Prop_Send, "m_flCloakMeter", cloak + 50.0);
 				}
 			}
 
@@ -3761,10 +3754,6 @@ Action SDKHookCB_OnTakeDamage(
 
 					if (StrEqual(class, "tf_projectile_energy_ring")) {
 						GetEntityClassname(weapon, class, sizeof(class));
-
-						if (StrEqual(class, "tf_weapon_drg_pomson")) {
-							players[victim].pomson_hit_tick = GetGameTickCount();
-						}
 
 						if (
 							(ItemIsEnabled(Wep_Bison) && StrEqual(class, "tf_weapon_raygun")) ||

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -710,15 +710,15 @@
 	}
 	"Pomson_PreGM"
 	{
-		"fi"	"Suurennettu ammuksen koko, läpäisee tiimikaverit, ylilat. ja verh. lasku ei putoa etäisyydellä, sytyttää tiimin Metsämiehen nuolet"
+		"fi"	"Suurennettu ammuksen koko, läpäisee tiimikaverit, ylilat. ja verh. lasku ei putoa etäisyydellä, sytyttää tiimin nuolet, tekee tyypitöntä vahinkoa"
 	}
 	"Pomson_Release"
 	{
-		"fi"	"Julkaisuversio: suurennettu ammuksen koko, läpäisee pelaajat, voi osua monta kertaa, ylilat. ja verh. lasku ei putoa etäisyydellä, sytyttää tiimin Metsämiehen nuolet"
+		"fi"	"Julkaisuversio: suurennettu ammuksen koko, läpäisee kohteet, voi osua monta kertaa, ylilat. ja verh. lasku ei putoa etäisyydellä, sytyttää tiimin nuolet, tekee tyypitöntä vahinkoa"
 	}
 	"Pomson_PreGM_Historical"
 	{
-		"fi"	"Ennen Gun Mettleä: suurennettu ammuksen koko, ylilat. ja verh. lasku ei putoa etäisyydellä, sytyttää tiimin Metsämiehen nuolet"
+		"fi"	"Ennen Gun Mettleä: suurennettu ammuksen koko, ylilat. ja verh. lasku ei putoa etäisyydellä, sytyttää tiimin nuolet, tekee tyypitöntä vahinkoa"
 	}	
 	"Powerjack_PreGM"
 	{
@@ -770,7 +770,11 @@
 	}
 	"Bison_PreMYM"
 	{
-		"fi"	"Ennen Meet your Matchiä: suurempi ammuksen koko, voi osua samaa pelaajaa monta kertaa, sytyttää tiimin Metsämiehen nuolet"
+		"fi"	"Ennen Meet your Matchiä: suurempi ammuksen koko, voi osua monta kertaa, sytyttää tiimin nuolet, tekee tyypitöntä vahinkoa"
+	}
+	"Bison_PreMYM_Historical"
+	{
+		"fi"	"Ennen Meet your Matchiä: suurempi ammuksen koko, voi osua monta kertaa, sytyttää tiimin nuolet, tekee tyypitöntä vahinkoa, vanha vahinkokaava"
 	}
 	"RocketJmp_Pre2013"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -709,7 +709,7 @@
 	}
 	"Pomson_Release"
 	{
-		"en"	"Reverted to release, same dmg as Bison, bigger hitbox size, passes thru players, no uber & cloak drain fall-off, lights up friendly Huntsman arrows, deals untyped dmg"
+		"en"	"Reverted to release, same dmg as Bison, bigger hitbox size, penetrates targets, no uber & cloak drain fall-off, lights up friendly Huntsman arrows, deals untyped dmg"
 	}
 	"Pomson_PreGM_Historical"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -85,7 +85,7 @@
 	}
 	"REVERT_LOADOUT_CHANGE_DISABLED"
 	{
-		"en"	"Disabled loadout change revert info. Enable them again by typing !revertsinfo or opening the reverts menu."
+		"en"	"Disabled loadout change revert info. Enable them again by typing !toggleinfo or opening the reverts menu."
 	}
 	"REVERT_MENU_TITLE"
 	{
@@ -813,11 +813,11 @@
 	}
 	"Shortstop_PreGM_Shove"
 	{
-		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, 40%% knockback vuln at all times, shares pistol ammo; modern shove is kept"
+		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo; modern shove is kept"
 	}
 	"Shortstop_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, 40%% knockback vuln at all times, shares pistol ammo, no shove"
+		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo, no shove"
 	}
 	"Sodapop_Pre2013"
 	{


### PR DESCRIPTION
### Summary of changes
Fix release Pomson variant draining more than intended at long range
Correct pre-gunmettle Dead Ringer cloak activation drain undoing when hit by unreverted Pomson at mid/long range

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on oob itemtest room

### Other Info
Fixes #178 
Release drain fix logic sourced from TF2 source code
