### PR TITLE
(i18n) Polish - !revertsinfo to !toggleinfo correction

### DIFF
--- a/translations/pl/reverts.phrases.txt
+++ b/translations/pl/reverts.phrases.txt
@@ -88,7 +88,7 @@
 	}
 	"REVERT_LOADOUT_CHANGE_DISABLED"
 	{
-		"pl"	"Wyłączono szczegóły dotyczące przywróconych broni po zmianie wyposażenia. Włącz je z powrotem wpisując !revertsinfo lub otwierając menu !reverts"
+		"pl"	"Wyłączono szczegóły dotyczące przywróconych broni po zmianie wyposażenia. Włącz je z powrotem wpisując !toggleinfo lub otwierając menu !reverts"
 	}
 	"REVERT_MENU_TITLE"
 	{


### PR DESCRIPTION
### Summary of changes
oops. forgot to update this one

### Testing Attestation
- [ ] - This change has been tested
- [X] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
original english version uses !toggleinfo. !revertsinfo just outputs text into the console, doesn't toggles the reverts info.
