### PR TITLE
(Reverts) Change pre-Gun Mettle Short Circuit alt-fire removal

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4744,6 +4744,7 @@ MRESReturn DHookCallback_CTFWeaponBase_SecondaryAttack(int entity) {
 			GetItemVariant(Wep_ShortCircuit) == 1 &&
 			StrEqual(class, "tf_weapon_mechanical_arm")
 		) {
+			// prevent alt-fire for pre-gunmettle short circuit
 			return MRES_Supercede;
 		}
 	}

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -802,11 +802,11 @@
 	}
 	"Circuit_PreMYM"
 	{
-		"fi"	"Ennen Meet your Matchiä: vaihtoehtotulitus tuhoaa projektiilejä edessä, maksaa 15 metallia"
+		"fi"	"Ennen Meet your Matchiä: vaihtoehtotulitus tuhoaa projektiilejä edessä, kuluttaa 15 metallia"
 	}
 	"Circuit_PreGM"
 	{
-		"fi"	"Ennen Gun Mettleä: ensisijatulitus tuhoaa projektiilejä, ei metallia apulaitteista kun käytössä, ei vaihtoehtotulitusta"
+		"fi"	"Ennen Gun Mettleä: ensisijatulitus tuhoaa projektiilejä (kuluttaa 5 metallia + 15 per tuhottu projektiili), ei metallia apulaitteista kun käytössä"
 	}
 	"Shortstop_PreMnvy_Shove"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -801,7 +801,7 @@
 	}
 	"Circuit_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, primary fire destroys projectiles, no metal from dispensers when active, no alt-fire"
+		"en"	"Reverted to pre-gunmettle, primary fire destroys projectiles (costs 5 metal + 15 per projectile destroyed), no metal from dispensers when active"
 	}
 	"Shortstop_PreMnvy_Shove"
 	{


### PR DESCRIPTION
### Summary of changes
fixes weapon not being switched when run out of metal, but causes client prediction issues with alt-fire

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway

### Other Info
also change item description
