### PR TITLE
(Revert) Pre-Gun Mettle Natascha Variant

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -93,6 +93,8 @@ public Plugin myinfo = {
 #define BALANCE_CIRCUIT_RECOVERY 0.5
 #define PLAYER_CENTER_HEIGHT (82.0 / 2.0) // constant for tf2 players
 
+#define TF_STUN_MOVEMENT	(1<<0) // used for pre-GM Natascha revert
+
 // game code defs
 #define EF_NODRAW 0x20
 #define FSOLID_USE_TRIGGER_BOUNDS 0x80
@@ -475,6 +477,7 @@ public void OnPluginStart() {
 	ItemDefine("cannon", "Cannon_PreTB", CLASSFLAG_DEMOMAN, Wep_LooseCannon);
 	ItemDefine("gardener", "Gardener_PreTB", CLASSFLAG_SOLDIER, Wep_MarketGardener);
 	ItemDefine("natascha", "Natascha_PreMYM", CLASSFLAG_HEAVY, Wep_Natascha);
+	ItemVariant(Wep_Natascha, "Natascha_PreGM");
 	ItemDefine("panic", "Panic_PreJI", CLASSFLAG_SOLDIER | CLASSFLAG_PYRO | CLASSFLAG_HEAVY | CLASSFLAG_ENGINEER, Wep_PanicAttack);
 	ItemDefine("persuader", "Persuader_PreTB", CLASSFLAG_DEMOMAN, Wep_Persian);
 	ItemDefine("pomson", "Pomson_PreGM", CLASSFLAG_ENGINEER, Wep_Pomson);
@@ -2091,8 +2094,19 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			}
 		}}
 		case 41: { if (ItemIsEnabled(Wep_Natascha)) {
-			TF2Items_SetNumAttributes(itemNew, 1);
-			TF2Items_SetAttribute(itemNew, 0, 738, 1.00); // spunup damage resistance
+			switch (GetItemVariant(Wep_Natascha)) {
+				case 0: {
+					TF2Items_SetNumAttributes(itemNew, 1);
+					TF2Items_SetAttribute(itemNew, 0, 738, 1.00); // spunup damage resistance
+				}
+				case 1: { // imported from NotnHeavy's pre-GM plugin
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 738, 1.00); // 0% damage resistance when below 50% health and spun up
+					TF2Items_SetAttribute(itemNew, 1, 32, 0.00); // On Hit: 0% chance to slow target
+					TF2Items_SetAttribute(itemNew, 2, 76, 1.50); // 50% max primary ammo on wearer
+					// no distance falloff for natascha stun handled elsewhere
+				}
+			}
 		}}
 		case 1153: { if (ItemIsEnabled(Wep_PanicAttack)) {
 			TF2Items_SetNumAttributes(itemNew, 11);
@@ -3692,6 +3706,7 @@ Action SDKHookCB_OnTakeDamage(
 			}
 
 			{
+				// pre-GM Black Box heal on hit
 				if (
 					ItemIsEnabled(Wep_BlackBox) &&
 					StrEqual(class,"tf_weapon_rocketlauncher") &&
@@ -3751,6 +3766,19 @@ Action SDKHookCB_OnTakeDamage(
 							return Plugin_Handled;
 						}
 					}
+				}
+			}
+
+			{
+				// Natascha stun. Stun amount/duration taken from TF2 source code. Imported from NotnHeavy's pre-GM plugin
+				if (
+					GetItemVariant(Wep_Natascha) == 1 &&
+					StrEqual(class,"tf_weapon_minigun") &&
+					GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 41
+				) {
+					// Slow enemy on hit, unless they're being healed by a medic
+					if (!TF2_IsPlayerInCondition(victim, TFCond_Healing))
+						TF2_StunPlayer(victim, 0.20, 0.60, TF_STUN_MOVEMENT, attacker);
 				}
 			}
 

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2104,7 +2104,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 0, 738, 1.00); // 0% damage resistance when below 50% health and spun up
 					TF2Items_SetAttribute(itemNew, 1, 32, 0.00); // On Hit: 0% chance to slow target
 					TF2Items_SetAttribute(itemNew, 2, 76, 1.50); // 50% max primary ammo on wearer
-					// no distance falloff for natascha stun handled elsewhere
+					// no distance falloff for natascha slowdown handled elsewhere
 				}
 			}
 		}}
@@ -3983,7 +3983,7 @@ Action SDKHookCB_OnTakeDamageAlive(
 		{
 			if (
 				((ItemIsEnabled(Wep_BrassBeast) && player_weapons[victim][Wep_BrassBeast]) ||
-				(ItemIsEnabled(Wep_Natascha) && player_weapons[victim][Wep_Natascha])) &&
+				(GetItemVariant(Wep_Natascha) == 0 && player_weapons[victim][Wep_Natascha])) &&
 				TF2_IsPlayerInCondition(victim, TFCond_Slowed) &&
 				TF2_GetPlayerClass(victim) == TFClass_Heavy
 			) {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3776,7 +3776,7 @@ Action SDKHookCB_OnTakeDamage(
 				) {
 					// Slow enemy on hit, unless they're being healed by a medic
 					if (!TF2_IsPlayerInCondition(victim, TFCond_Healing))
-						TF2_StunPlayer(victim, 0.20, 0.60, TF_STUN_MOVEMENT, attacker);
+						TF2_StunPlayer(victim, 0.20, 0.60, TF_STUNFLAG_SLOWDOWN, attacker);
 				}
 			}
 

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -93,8 +93,6 @@ public Plugin myinfo = {
 #define BALANCE_CIRCUIT_RECOVERY 0.5
 #define PLAYER_CENTER_HEIGHT (82.0 / 2.0) // constant for tf2 players
 
-#define TF_STUN_MOVEMENT	(1<<0) // used for pre-GM Natascha revert
-
 // game code defs
 #define EF_NODRAW 0x20
 #define FSOLID_USE_TRIGGER_BOUNDS 0x80

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3921,6 +3921,7 @@ Action SDKHookCB_OnTakeDamage(
 					// Slow enemy on hit, unless they're being healed by a medic
 					if (!TF2_IsPlayerInCondition(victim, TFCond_Healing))
 						TF2_StunPlayer(victim, 0.20, 0.60, TF_STUNFLAG_SLOWDOWN, attacker);
+				}
 			}
         
 			{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -695,6 +695,10 @@
 	{
 		"en"	"Reverted to pre-matchmaking, 20%% damage resistance (6.7%% against crits) when spun up at any health"
 	}
+	"Natascha_PreGM"
+	{
+		"en"	"Reverted to pre-gunmettle, no damage resistance, 300 max ammo, stun has no distance falloff"
+	}	
 	"Panic_PreJI"
 	{
 		"en"	"Reverted to pre-inferno, hold fire to load, let go to release, fire faster with bigger spread on lower health"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -697,7 +697,7 @@
 	}
 	"Natascha_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, no damage resistance, 300 max ammo, stun has no distance falloff"
+		"en"	"Reverted to pre-gunmettle, full slowdown at any distance, 300 max ammo, no damage resistance when spun up"
 	}	
 	"Panic_PreJI"
 	{


### PR DESCRIPTION
### Summary of changes
### [The Natascha (Pre-Gun Mettle)](https://wiki.teamfortress.com/w/index.php?title=Natascha&oldid=1886268)
- On Hit: 100% chance to slow target (no distance falloff)
- +50% max primary ammo on wearer
- -25% damage penalty
- 30% slower spin up time
- No damage resistance when spun up

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
dev room in itemtest, moving +forward away from the heavy using cl_showpos 1

### Other Info
Imported from NotnHeavy's plugin, credits to him