### PR TITLE
Rename sm_reverts__extras and add an option to disable moonshot message

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -87,6 +87,14 @@
 	{
 		"en"	"Disabled loadout change revert info. Enable them again by typing !toggleinfo or opening the reverts menu."
 	}
+	"REVERT_MOONSHOT_ENABLED"
+	{
+		"en"	"Moonshot message enabled. Use the reverts menu to disable it."
+	}
+	"REVERT_MOONSHOT_DISABLED"
+	{
+		"en"	"Moonshot message disabled. Use the reverts menu to enable it."
+	}
 	"REVERT_MENU_TITLE"
 	{
 		"en"	"Weapon Reverts"
@@ -102,6 +110,10 @@
 	"REVERT_MENU_TOGGLE_LOADOUT_CHANGE"
 	{
 		"en"	"Toggle loadout change revert info"
+	}
+	"REVERT_MENU_TOGGLE_MOONSHOT"
+	{
+		"en"	"Toggle moonshot message"
 	}
 
 	// item names


### PR DESCRIPTION
### Summary of changes
Rename sm_reverts__extras and add an option to disable moonshot message in the menu

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Tested if cookie value can be set properly

### Other Info
N/A
