### PR TITLE
(Reverts) Add pre-Blue Moon Atomizer variant

### DIFF
--- a/cfg/reverts.cfg
+++ b/cfg/reverts.cfg
@@ -1,17 +1,20 @@
 // Weapon reverts preset config file used by Castaway.tf
 
 sm_reverts__enable_dropped_weapon 1
+sm_reverts__extras 1
 sm_reverts__item_airblast 0
 sm_reverts__item_scottish 0
 sm_reverts__item_tomislav 0
 sm_reverts__item_darwin 0
-sm_reverts__item_jag 0
+sm_reverts__item_jag 1
 sm_reverts__item_gunboats 0
-sm_reverts__item_quickiebomb 0
+sm_reverts__item_quickiebomb 1
+sm_reverts__item_pomson 2
+sm_reverts__item_circuit 2
+
 sm_reverts__item_crocostyle 0
 sm_reverts__item_expert 0
 sm_reverts__item_gasjockey 0
 sm_reverts__item_hibernate 0
 sm_reverts__item_spdelivery 0
-
 sm_reverts__item_saharan 2

--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -3,7 +3,7 @@
 
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
-sm_reverts__item_miniramp 1
+sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 1
 sm_reverts__item_atomizer 1

--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -42,7 +42,7 @@ sm_reverts__item_glovesru 1
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 0
-sm_reverts__item_jag 0
+sm_reverts__item_jag 1
 sm_reverts__item_liberty 1
 sm_reverts__item_lochload 1
 sm_reverts__item_cannon 1
@@ -50,11 +50,11 @@ sm_reverts__item_gardener 1
 sm_reverts__item_natascha 1
 sm_reverts__item_panic 1
 sm_reverts__item_persuader 1
-sm_reverts__item_pomson 1
+sm_reverts__item_pomson 2
 sm_reverts__item_powerjack 1
 sm_reverts__item_pocket 1
 sm_reverts__item_quickfix 1
-sm_reverts__item_quickiebomb 0
+sm_reverts__item_quickiebomb 1
 sm_reverts__item_razorback 1
 sm_reverts__item_rescueranger 1
 sm_reverts__item_reserve 1
@@ -63,7 +63,7 @@ sm_reverts__item_rocketjmp 1
 sm_reverts__item_saharan 2
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
-sm_reverts__item_circuit 1
+sm_reverts__item_circuit 2
 sm_reverts__item_shortstop 1
 sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -6,7 +6,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
-sm_reverts__item_atomizer 0
+sm_reverts__item_atomizer 2
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
 sm_reverts__item_basejump 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -79,8 +79,7 @@ sm_reverts__item_razorback 1
 sm_reverts__item_rescueranger 1
 sm_reverts__item_reserve 1
 sm_reverts__item_bison 1
-sm_reverts__item_rocketjmp 2
-// rocket jumper lacks accurate pre-GM version (can pick up flag, can't survive kamikaze taunt)
+sm_reverts__item_rocketjmp 0
 sm_reverts__item_saharan 0
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
@@ -92,7 +91,6 @@ sm_reverts__item_spdelivery 0
 sm_reverts__item_splendid 1
 sm_reverts__item_spycicle 1
 sm_reverts__item_stkjumper 0
-// sticky jumper lacks pre-GM version (can pick up flag, 2 stickies out only)
 sm_reverts__item_sleeper 1
 // sydney sleeper lack accurate pre-GM version. i'm enabling this revert regardless
 sm_reverts__item_turner 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -100,7 +100,7 @@ sm_reverts__item_turner 1
 sm_reverts__item_tomislav 0
 // tomislav lacks pre-GM version (+10% spin up time, no accuracy bonus)
 sm_reverts__item_tribalshiv 0
-sm_reverts__item_caber 0
+sm_reverts__item_caber 1
 sm_reverts__item_vitasaw 1
 sm_reverts__item_warrior 1
 // warrior's spirit lacks pre-GM version. enabled this since it's the closest version

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -403,6 +403,7 @@ public void OnPluginStart() {
 	ItemDefine("swords", "Swords_PreTB", CLASSFLAG_DEMOMAN, Feat_Sword);
 	ItemDefine("ambassador", "Ambassador_PreJI", CLASSFLAG_SPY, Wep_Ambassador);
 	ItemDefine("atomizer", "Atomizer_PreJI", CLASSFLAG_SCOUT, Wep_Atomizer);
+	ItemVariant(Wep_Atomizer, "Atomizer_PreBM");
 	ItemDefine("axtinguish", "Axtinguisher_PreLW", CLASSFLAG_PYRO, Wep_Axtinguisher);
 	ItemVariant(Wep_Axtinguisher, "Axtinguisher_PreTB");
 	ItemDefine("backburner", "Backburner_PreHat", CLASSFLAG_PYRO, Wep_Backburner);
@@ -926,13 +927,19 @@ public void OnGameFrame() {
 								StrEqual(class, "tf_weapon_bat") &&
 								GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 450
 							) {
-								if (ItemIsEnabled(Wep_Atomizer)) {
-									airdash_limit_new = 2;
-								} else {
-									if (weapon == GetEntPropEnt(idx, Prop_Send, "m_hActiveWeapon")) {
-										airdash_limit_old = 2;
-										airdash_limit_new = 2;
+								switch (GetItemVariant(Wep_Atomizer)) {
+									case -1: {
+										if (weapon == GetEntPropEnt(idx, Prop_Send, "m_hActiveWeapon")) {
+											airdash_limit_old = 2;
+											airdash_limit_new = 2;
+										}
 									}
+									case 0: airdash_limit_new = 2;
+									case 1: {
+										if (weapon == GetEntPropEnt(idx, Prop_Send, "m_hActiveWeapon")) {
+											airdash_limit_new = 2;
+										}
+									}	
 								}
 							}
 						}
@@ -963,7 +970,9 @@ public void OnGameFrame() {
 								ItemIsEnabled(Wep_Atomizer)
 							) {
 								// atomizer global jump
-								SDKHooks_TakeDamage(idx, idx, idx, 10.0, (DMG_BULLET|DMG_PREVENT_PHYSICS_FORCE), -1, NULL_VECTOR, NULL_VECTOR);
+								if (GetItemVariant(Wep_Atomizer) == 0) {
+									SDKHooks_TakeDamage(idx, idx, idx, 10.0, (DMG_BULLET|DMG_PREVENT_PHYSICS_FORCE), -1, NULL_VECTOR, NULL_VECTOR);
+								}
 
 								if (airdash_limit_new > airdash_limit_old) {
 									// only play sound if the game doesn't play it
@@ -1785,11 +1794,20 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 0, 868, 0.0); // crit dmg falloff
 		}}
 		case 450: { if (ItemIsEnabled(Wep_Atomizer)) {
-			TF2Items_SetNumAttributes(itemNew, 4);
-			TF2Items_SetAttribute(itemNew, 0, 5, 1.30); // fire rate penalty
-			TF2Items_SetAttribute(itemNew, 1, 138, 0.80); // dmg penalty vs players
-			TF2Items_SetAttribute(itemNew, 2, 250, 0.0); // air dash count
-			TF2Items_SetAttribute(itemNew, 3, 773, 1.0); // single wep deploy time increased
+			switch (GetItemVariant(Wep_Atomizer)) {
+				case 1: { // Pre-Blue Moon
+					TF2Items_SetNumAttributes(itemNew, 1);
+					TF2Items_SetAttribute(itemNew, 0, 250, 0.0); // air dash count
+				}
+				default: { // Pre-Jungle Inferno
+					TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetAttribute(itemNew, 0, 5, 1.30); // fire rate penalty
+					TF2Items_SetAttribute(itemNew, 1, 138, 0.80); // dmg penalty vs players
+					TF2Items_SetAttribute(itemNew, 2, 250, 0.0); // air dash count
+					TF2Items_SetAttribute(itemNew, 3, 773, 1.0); // single wep deploy time increased
+				}
+			}
+				
 		}}
 		case 38, 457, 1000: { if (ItemIsEnabled(Wep_Axtinguisher)) {
 			TF2Items_SetNumAttributes(itemNew, 5);
@@ -3535,6 +3553,21 @@ Action SDKHookCB_OnTakeDamage(
 				if (
 					GetItemVariant(Wep_SodaPopper) == 0 &&
 					TF2_IsPlayerInCondition(attacker, TFCond_CritHype) == true &&
+					TF2_IsPlayerInCondition(victim, TFCond_MarkedForDeathSilent) == false
+				) {
+					TF2_AddCondition(victim, TFCond_MarkedForDeathSilent, 0.001, 0);
+				}
+			}
+
+			{
+				// pre-bluemoon atomizer airborne minicrits
+
+				if (
+					GetItemVariant(Wep_Atomizer) == 1 &&
+					StrEqual(class, "tf_weapon_bat") &&
+					GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 450 &&
+					(GetEntityFlags(attacker) & FL_ONGROUND) == 0 &&
+					GetEntProp(attacker, Prop_Data, "m_nWaterLevel") == 0 &&
 					TF2_IsPlayerInCondition(victim, TFCond_MarkedForDeathSilent) == false
 				) {
 					TF2_AddCondition(victim, TFCond_MarkedForDeathSilent, 0.001, 0);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -974,6 +974,10 @@ public void OnGameFrame() {
 									SDKHooks_TakeDamage(idx, idx, idx, 10.0, (DMG_BULLET|DMG_PREVENT_PHYSICS_FORCE), -1, NULL_VECTOR, NULL_VECTOR);
 								}
 
+								// emit purple smoke (still shows white smoke too but good enough for now)
+								GetEntPropVector(idx, Prop_Send, "m_vecOrigin", pos1);
+								ParticleShowSimple("doublejump_puff_alt", pos1);
+
 								if (airdash_limit_new > airdash_limit_old) {
 									// only play sound if the game doesn't play it
 									EmitSoundToAll("misc/banana_slip.wav", idx, SNDCHAN_AUTO, 30, (SND_CHANGEVOL|SND_CHANGEPITCH), 1.0, 100);

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -448,6 +448,10 @@
 	{
 		"fi"	"Ennen Jungle Infernoa: kolmoishyppy on passiivinen, kolmoishyppy aiheuttaa 10 vahinkoa"
 	}
+	"Atomizer_PreBM"
+	{
+		"fi"	"Ennen Blue Moonia: mailan ei tarvi olla täysin vedettynä esiin, jotta voi kolmoishypätä"
+	}
 	"Axtinguisher_PreLW"
 	{
 		"fi"	"Ennen Love&Waria: aina tekee kriittisiä osumia (195) palaviin pelaajiin, ei nopeuslisää taposta"
@@ -738,7 +742,7 @@
 	}
 	"Pocket_PreBM"
 	{
-		"fi"	"Ennen vuotta 2018: osumasta saa jopa +7 terveyttä"
+		"fi"	"Ennen Blue Moonia: osumasta saa jopa +7 terveyttä"
 	}
 	"Quickfix_PreTB"
 	{
@@ -858,7 +862,7 @@
 	}
 	"Sleeper_PreBM"
 	{
-		"fi"	"Ennen vuotta 2018: pääosumat ja täysin ladatut osumat roiskauttavat Jaratea, ei vähennä Jaraten latausaikaa"
+		"fi"	"Ennen Blue Moonia: pääosumat ja täysin ladatut osumat roiskauttavat Jaratea, ei vähennä Jaraten latausaikaa"
 	}
 	"Turner_PreTB"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -443,6 +443,10 @@
 	{
 		"en"	"Reverted to pre-inferno, can always triple jump, taking 10 damage each time"
 	}
+	"Atomizer_PreBM"
+	{
+		"en"	"Reverted to pre-bluemoon, can triple jump when not fully deployed"
+	}
 	"Axtinguisher_PreLW"
 	{
 		"en"	"Reverted to pre-love&war, always deals 195 damage crits to burning targets, no speedboost on kill"


### PR DESCRIPTION
### Summary of changes
The Atomizer
- Grants Triple Jump while deployed. (does not have to be fully deployed)
- Melee attacks mini-crit while airborne.
- -15% damage vs players
- This weapon deploys 50% slower

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway

### Other Info
also add purple smoke to atomizer jump
