### PR TITLE
fix typo in votescramble chinese translations

### DIFF
--- a/translations/chi/votescramble.phrases.txt
+++ b/translations/chi/votescramble.phrases.txt
@@ -27,7 +27,7 @@
 	}
 	"VOTESCRAMBLE_COOLDOWN"
 	{
-		"en"	"对不起，随机重组团队投票正在冷却时间中。"
+		"chi"	"对不起，随机重组团队投票正在冷却时间中。"
 	}
 	"VOTESCRAMBLE_WAITING_FOR_PLAYERS"
 	{


### PR DESCRIPTION
### Summary of changes
fix typo in votescramble chinese translations

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
N/A

### Other Info
N/A
