### PR TITLE
(Reverts) CVars to disable Rocket Jumper and Sticky Jumper PASS Time JACK pickups + Cow Mangler base version swap

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -207,7 +207,11 @@ ConVar cvar_ref_tf_parachute_aircontrol;
 ConVar cvar_ref_tf_parachute_maxspeed_onfire_z;
 ConVar cvar_ref_tf_scout_hype_mod;
 
-bool g_bIsPasstime;	// Check for passtime gamemode used for the Rocket Jumper and Sticky Jumper reverts
+// PASS Time JACK pickup prevention by Rocket Jumper and Sticky Jumper weapons
+ConVar cvar_passtime_disable_pickup_rocketjmp;
+ConVar cvar_passtime_disable_pickup_stkjumper;
+bool g_bIsPasstime_RocketJumper;	// Check if map has PASS Time gamemode logic, used for the Rocket Jumper reverts
+bool g_bIsPasstime_StickyJumper;	// Check if map has PASS Time gamemode logic, used for the Sticky Jumper reverts
 
 #if defined MEMORY_PATCHES
 MemoryPatch patch_RevertDisciplinaryAction;
@@ -417,6 +421,8 @@ public void OnPluginStart() {
 #endif
 	cvar_no_reverts_info_by_default = CreateConVar("sm_reverts__no_reverts_info_on_spawn", "0", (PLUGIN_NAME ... " - Disable loadout change reverts info by default"), _, true, 0.0, true, 1.0);
 	cvar_pre_toughbreak_switch = CreateConVar("sm_reverts__pre_toughbreak_switch", "0", (PLUGIN_NAME ... " - Use pre-toughbreak weapon switch time (0.67 sec instead of 0.5 sec)"), _, true, 0.0, true, 1.0);
+	cvar_passtime_disable_pickup_rocketjmp = CreateConVar("sm_reverts__passtime_disable_pickup_rocketjmp", "1", (PLUGIN_NAME ... " - If next map is PASS Time, disable picking up the PASS Time JACK for all Rocket Jumper variants"), _, true, 0.0, true, 1.0);
+	cvar_passtime_disable_pickup_stkjumper = CreateConVar("sm_reverts__passtime_disable_pickup_stkjumper", "1", (PLUGIN_NAME ... " - If next map is PASS Time, disable picking up the PASS Time JACK for all Sticky Jumper variants"), _, true, 0.0, true, 1.0);
 
 #if defined MEMORY_PATCHES
 	cvar_dropped_weapon_enable.AddChangeHook(OnDroppedWeaponCvarChange);
@@ -917,17 +923,31 @@ public void OnMapStart() {
 	PrecacheScriptSound("Jar.Explode");
 	PrecacheScriptSound("Player.ResistanceLight");
 
-	g_bIsPasstime = false;
+	if (cvar_passtime_disable_pickup_rocketjmp.BoolValue) {
+		g_bIsPasstime_RocketJumper = false;
+		int ent = -1;
+		while ((ent = FindEntityByClassname(ent, "passtime_logic")) != -1)
+		{
+			g_bIsPasstime_RocketJumper = true;
+			break;
+		}
 
-	int ent = -1;
-	while ((ent = FindEntityByClassname(ent, "passtime_logic")) != -1)
-	{
-		g_bIsPasstime = true;
-		break;
+		//if(g_bIsPasstime_RocketJumper) PrintToServer("Passtime map detected for Rocket Jumper (g_bIsPasstime_RocketJumper = %b)", g_bIsPasstime_RocketJumper);
+		//else if(!g_bIsPasstime_RocketJumper) PrintToServer("Passtime map NOT detected for Rocket Jumper (g_bIsPasstime_RocketJumper = %b)", g_bIsPasstime_RocketJumper);
 	}
-	
-	if(g_bIsPasstime) PrintToServer("Passtime map detected (g_bIsPasstime = %b)", g_bIsPasstime);
-	else if(!g_bIsPasstime) PrintToServer("Passtime map NOT detected (g_bIsPasstime = %b)", g_bIsPasstime);
+
+	if (cvar_passtime_disable_pickup_stkjumper.BoolValue) {
+		g_bIsPasstime_StickyJumper = false;
+		int ent = -1;
+		while ((ent = FindEntityByClassname(ent, "passtime_logic")) != -1)
+		{
+			g_bIsPasstime_StickyJumper = true;
+			break;
+		}
+
+		//if(g_bIsPasstime_StickyJumper) PrintToServer("Passtime map detected for Sticky Jumper (g_bIsPasstime_StickyJumper = %b)", g_bIsPasstime_StickyJumper);
+		//else if(!g_bIsPasstime_StickyJumper) PrintToServer("Passtime map NOT detected for Sticky Jumper (g_bIsPasstime_StickyJumper = %b)", g_bIsPasstime_StickyJumper);
+	}	
 }
 
 public void OnGameFrame() {
@@ -1951,12 +1971,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				}				
 				case 1: { // RocketJmp_Release
 					TF2Items_SetNumAttributes(itemNew, 2);
-					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime_RocketJumper ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 1, 15, 1.0); // crit mod disabled
 				}
 				case 2: { // RocketJmp_Pre2011 (December 22, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 6);
-					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime_RocketJumper ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 1, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 2, 61, 2.00); // 100% dmg taken from fire increased
 					TF2Items_SetAttribute(itemNew, 3, 65, 2.00); // 100% dmg taken from blast increased
@@ -1965,7 +1985,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				}
 				case 3: { // RocketJmp_Oct2010 (October 27, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 4);
-					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime_RocketJumper ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 1, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 2, 125, -100.0); // max health additive penalty
 					TF2Items_SetAttribute(itemNew, 3, 207, 0.0); // remove self blast dmg; blast dmg to self increased
@@ -2478,12 +2498,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				case 1: { // StkJumper_Pre2013_Intel (Manniversary Update version)
 					TF2Items_SetNumAttributes(itemNew, 2);
 					TF2Items_SetAttribute(itemNew, 0, 89, 0.0); // max pipebombs decreased
-					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime_StickyJumper ? 1.0 : 0.0); // cannot_pick_up_intelligence
 				}
 				case 2: { // StkJumper_Pre2011 (December 22, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 7);
 					TF2Items_SetAttribute(itemNew, 0, 89, 0.0); // max pipebombs decreased
-					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime_StickyJumper ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 2, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 3, 61, 2.00); // 100% dmg taken from fire increased
 					TF2Items_SetAttribute(itemNew, 4, 65, 2.00); // 100% dmg taken from blast increased
@@ -2493,7 +2513,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				case 3: { // StkJumper_ReleaseDay2 (October 28, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 5);
 					TF2Items_SetAttribute(itemNew, 0, 89, 0.0); // max pipebombs decreased
-					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime_StickyJumper ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 2, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 3, 125, -75.0); // max health additive penalty
 					TF2Items_SetAttribute(itemNew, 4, 207, 0.0); // remove self blast dmg; blast dmg to self increased

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -457,8 +457,8 @@ public void OnPluginStart() {
 	ItemDefine("targe", "Targe_PreTB", CLASSFLAG_DEMOMAN, Wep_CharginTarge);
 	ItemDefine("claidheamh", "Claidheamh_PreTB", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
 	ItemDefine("carbine", "Carbine_Release", CLASSFLAG_SNIPER, Wep_CleanerCarbine);
-	ItemDefine("cowmangler", "CowMangler_Release", CLASSFLAG_SOLDIER, Wep_CowMangler);
-	ItemVariant(Wep_CowMangler, "CowMangler_Pre2013");
+	ItemDefine("cowmangler", "CowMangler_Pre2013", CLASSFLAG_SOLDIER, Wep_CowMangler);
+	ItemVariant(Wep_CowMangler, "CowMangler_Release");
 #if defined MEMORY_PATCHES
 	ItemDefine("cozycamper","CozyCamper_PreMYM", CLASSFLAG_SNIPER, Wep_CozyCamper, true);
 #endif
@@ -2073,18 +2073,18 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 441: { if (ItemIsEnabled(Wep_CowMangler)) {
 			switch (GetItemVariant(Wep_CowMangler)) {
 				case 0: {
-					TF2Items_SetNumAttributes(itemNew, 3);
-					TF2Items_SetAttribute(itemNew, 0, 869, 0.0); // crits_become_minicrits
-					TF2Items_SetAttribute(itemNew, 1, 288, 1.0); // no_crit_boost; this attribute does not work properly! you still get crits but without the crit glow
-					TF2Items_SetAttribute(itemNew, 2, 335, 1.25); // mult_clipsize_upgrade; increase clip to 5 shots, attrib 4 doesn't work
-				}
-				case 1: {
 					TF2Items_SetNumAttributes(itemNew, 5);
 					TF2Items_SetAttribute(itemNew, 0, 869, 0.0); // crits_become_minicrits
 					TF2Items_SetAttribute(itemNew, 1, 288, 1.0); // no_crit_boost
 					TF2Items_SetAttribute(itemNew, 2, 335, 1.25); // mult_clipsize_upgrade
 					TF2Items_SetAttribute(itemNew, 3, 96, 1.05); // mult_reload_time; 5% slower reload time
 					TF2Items_SetAttribute(itemNew, 4, 1, 0.90); // mult_dmg; 10% damage penalty
+				}
+				case 1: {
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 869, 0.0); // crits_become_minicrits
+					TF2Items_SetAttribute(itemNew, 1, 288, 1.0); // no_crit_boost; this attribute does not work properly! you still get crits but without the crit glow
+					TF2Items_SetAttribute(itemNew, 2, 335, 1.25); // mult_clipsize_upgrade; increase clip to 5 shots, attrib 4 doesn't work
 				}
 				// no crit boost attribute fix handled elsewhere in SDKHookCB_OnTakeDamage
 			}
@@ -4169,7 +4169,7 @@ Action SDKHookCB_OnTakeDamage(
 
 						if (
 							ItemIsEnabled(Wep_CowMangler) &&
-							GetItemVariant(Wep_CowMangler) == 0 &&
+							GetItemVariant(Wep_CowMangler) == 1 &&
 							StrEqual(class, "tf_weapon_particle_cannon")
 						) {
 							GetEntPropVector(inflictor, Prop_Send, "m_vecOrigin", pos1);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -206,6 +206,9 @@ ConVar cvar_ref_tf_fireball_radius;
 ConVar cvar_ref_tf_parachute_aircontrol;
 ConVar cvar_ref_tf_parachute_maxspeed_onfire_z;
 ConVar cvar_ref_tf_scout_hype_mod;
+
+bool g_bIsPasstime;	// Check for passtime gamemode used for the Rocket Jumper and Sticky Jumper reverts
+
 #if defined MEMORY_PATCHES
 MemoryPatch patch_RevertDisciplinaryAction;
 // If Windows, prepare additional vars for Disciplinary Action.
@@ -913,6 +916,18 @@ public void OnMapStart() {
 	PrecacheSound("misc/banana_slip.wav");
 	PrecacheScriptSound("Jar.Explode");
 	PrecacheScriptSound("Player.ResistanceLight");
+
+	g_bIsPasstime = false;
+
+	int ent = -1;
+	while ((ent = FindEntityByClassname(ent, "passtime_logic")) != -1)
+	{
+		g_bIsPasstime = true;
+		break;
+	}
+	
+	if(g_bIsPasstime) PrintToServer("Passtime map detected (g_bIsPasstime = %b)", g_bIsPasstime);
+	else if(!g_bIsPasstime) PrintToServer("Passtime map NOT detected (g_bIsPasstime = %b)", g_bIsPasstime);
 }
 
 public void OnGameFrame() {
@@ -1936,12 +1951,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				}				
 				case 1: { // RocketJmp_Release
 					TF2Items_SetNumAttributes(itemNew, 2);
-					TF2Items_SetAttribute(itemNew, 0, 400, 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 1, 15, 1.0); // crit mod disabled
 				}
 				case 2: { // RocketJmp_Pre2011 (December 22, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 6);
-					TF2Items_SetAttribute(itemNew, 0, 400, 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 1, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 2, 61, 2.00); // 100% dmg taken from fire increased
 					TF2Items_SetAttribute(itemNew, 3, 65, 2.00); // 100% dmg taken from blast increased
@@ -1950,13 +1965,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				}
 				case 3: { // RocketJmp_Oct2010 (October 27, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 4);
-					TF2Items_SetAttribute(itemNew, 0, 400, 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 0, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 1, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 2, 125, -100.0); // max health additive penalty
 					TF2Items_SetAttribute(itemNew, 3, 207, 0.0); // remove self blast dmg; blast dmg to self increased
 				}	
-			}
-					
+			}		
 		}}
 		case 730: { if (ItemIsEnabled(Wep_Beggars)) {
 			TF2Items_SetNumAttributes(itemNew, 1);
@@ -2464,12 +2478,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				case 1: { // StkJumper_Pre2013_Intel (Manniversary Update version)
 					TF2Items_SetNumAttributes(itemNew, 2);
 					TF2Items_SetAttribute(itemNew, 0, 89, 0.0); // max pipebombs decreased
-					TF2Items_SetAttribute(itemNew, 1, 400, 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
 				}
 				case 2: { // StkJumper_Pre2011 (December 22, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 7);
 					TF2Items_SetAttribute(itemNew, 0, 89, 0.0); // max pipebombs decreased
-					TF2Items_SetAttribute(itemNew, 1, 400, 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 2, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 3, 61, 2.00); // 100% dmg taken from fire increased
 					TF2Items_SetAttribute(itemNew, 4, 65, 2.00); // 100% dmg taken from blast increased
@@ -2479,7 +2493,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				case 3: { // StkJumper_ReleaseDay2 (October 28, 2010 version)
 					TF2Items_SetNumAttributes(itemNew, 5);
 					TF2Items_SetAttribute(itemNew, 0, 89, 0.0); // max pipebombs decreased
-					TF2Items_SetAttribute(itemNew, 1, 400, 0.0); // cannot_pick_up_intelligence
+					TF2Items_SetAttribute(itemNew, 1, 400, g_bIsPasstime ? 1.0 : 0.0); // cannot_pick_up_intelligence
 					TF2Items_SetAttribute(itemNew, 2, 15, 1.0); // crit mod disabled
 					TF2Items_SetAttribute(itemNew, 3, 125, -75.0); // max health additive penalty
 					TF2Items_SetAttribute(itemNew, 4, 207, 0.0); // remove self blast dmg; blast dmg to self increased

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -557,13 +557,13 @@
 	{
 		"fi"	"Julkaisuversio: tapot antavat 3 sekunnin kriittisyystehosteen, 35%% hitaampi tulitusnopeus (25%%:sta)"
 	}
-	"CowMangler_Release"
-	{
-		"fi"	"Julkaisuversio: 5 ammusta, ei voi kriittisyystehostaa"
-	}
 	"CowMangler_Pre2013"
 	{
 		"fi"	"Ennen 2013 kesää: 5 ammusta, ei voi kriittisyystehostaa, -10%% vahinkovähennys, 5%% hitaampi latausaika"
+	}	
+	"CowMangler_Release"
+	{
+		"fi"	"Julkaisuversio: 5 ammusta, ei voi kriittisyystehostaa"
 	}
 	"CozyCamper_PreMYM"
 	{

--- a/translations/fr/reverts.phrases.txt
+++ b/translations/fr/reverts.phrases.txt
@@ -555,13 +555,13 @@
 	{
 		"fr"	"Réversion à la version d'origine, crits pendant 3s après avoir tué, cadence 35%% plus lente (au lieu de 25%%)"
 	}
-	"CowMangler_Release"
-	{
-		"fr"	"Réversion à la version d'origine, chargeur de 5 tirs, ne peut pas être crit-boosté"
-	}
 	"CowMangler_Pre2013"
 	{
 		"fr"	"Réversion à pré-Été 2013, chargeur de 5 tirs, ne peut pas être crit-boosté, -10%% de dégâts, recharge 5%% plus lente"
+	}	
+	"CowMangler_Release"
+	{
+		"fr"	"Réversion à la version d'origine, chargeur de 5 tirs, ne peut pas être crit-boosté"
 	}
 	"CozyCamper_PreMYM"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -552,13 +552,13 @@
 	{
 		"en"	"Reverted to release, crits for 3 seconds on kill, 35%% slower fire rate (from 25%%)"
 	}
-	"CowMangler_Release"
-	{
-		"en"	"Reverted to release, 5 shots, cannot be crit-boosted"
-	}
 	"CowMangler_Pre2013"
 	{
 		"en"	"Reverted to pre-Summer 2013, 5 shots, cannot be crit-boosted, -10%% dmg penalty, 5%% slower reload time"
+	}	
+	"CowMangler_Release"
+	{
+		"en"	"Reverted to release, 5 shots, cannot be crit-boosted"
 	}
 	"CozyCamper_PreMYM"
 	{


### PR DESCRIPTION
### Summary of changes
This adds two (2) CVars to disable picking up the PASS Time JACK for the Rocket Jumper and the Sticky Jumper whenever the next map is a PASS Time map:

`sm_reverts__passtime_disable_pickup_rocketjmp 1`
`sm_reverts__passtime_disable_pickup_stkjumper 1`

By default, both CVars have values set to 1, which means that whenever the variants that allow picking up the intel are used in the server, they are not able to pick up the PASS Time JACK. This does it by detecting if a map is on PASS Time, then applies the no Intelligence pickup attribute. This means that the Jumper variants that allow intel pickup are able to capture the flag on normal CTF maps.

As for why I decided to have separate CVars for the Jumper weapons, the problem stems from the Sticky Jumper allowing the Demoman to go to places very fast and easily. The Rocket Jumper still has the problem, but it tends to only apply to skilled rocket jumper Soldiers. By doing this, a server owner should still have some flexibility if they want to allow the Rocket Jumper variants to pick up the PASS Time JACK since rocket jumping very fast (pogo-ing) tends to be more difficult compared to plopping down 4-8 stickies then detonating it with the Sticky Jumper.

Additionally, the Cow Mangler 5000 base version has been swapped with the Pre2013 version, so variant 1 for the Cow Mangler is the release version now.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Going from ctf_turbine and pass_brickyard, picking up and capturing intel and PASS Time JACK.

### Other Info
Note that the Demoman cannot detonate his stickies whenever he picks up the PASS Time JACK. This happens in the base game too without weapon reverts.
