### PR TITLE
(Reverts) Add to wrangler preLW - damage falloff based on user's position

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -962,7 +962,7 @@
 	}
 	"Wrangler_PreLW"
 	{
-		"en"	"Reverted to pre-love&war, fully repair and refill while shield is up, sentry active in 1 second on death, no damage falloff beyond scan range"
+		"en"	"Reverted to pre-love&war, fully repair and refill while shield is up, sentry active in 1 second on death, no damage falloff beyond scan range, damage falloff based on user's position"
 	}
 	"Eternal_PreJI"
 	{


### PR DESCRIPTION
### Summary of changes
Damage falloff based on user's position was also stated in the code too
Add this to reverts.phrases.txt
Other Finnish translation will need to be updated too @haaksirikko 

### Testing Attestation
- [ ] - This change has been tested
- [X] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
[Any other information you'd like to provide]
