### PR TITLE
(Reverts) Add more item variants, do shove removal in DHook

### DIFF
--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -41,7 +41,7 @@ sm_reverts__item_expert 0
 sm_reverts__item_fiststeel 1
 sm_reverts__item_guillotine 1
 sm_reverts__item_gasjockey 0
-sm_reverts__item_glovesru 1
+sm_reverts__item_glovesru 2
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 0

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -41,7 +41,7 @@ sm_reverts__item_expert 0
 sm_reverts__item_fiststeel 0
 sm_reverts__item_guillotine 1
 sm_reverts__item_gasjockey 0
-sm_reverts__item_glovesru 1
+sm_reverts__item_glovesru 2
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 0
 sm_reverts__item_hibernate 0

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -68,7 +68,7 @@ sm_reverts__item_saharan 0
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 0
-sm_reverts__item_shortstop 3
+sm_reverts__item_shortstop 2
 sm_reverts__item_sodapop 0
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 0

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -30,7 +30,7 @@ sm_reverts__item_critcola 2
 sm_reverts__item_crocostyle 0
 sm_reverts__item_dalokohsbar 1
 sm_reverts__item_darwin 0
-sm_reverts__item_ringer 1
+sm_reverts__item_ringer 2
 sm_reverts__item_degreaser 1
 sm_reverts__item_disciplinary 1
 sm_reverts__item_dragonfury 1

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -39,7 +39,7 @@ sm_reverts__item_fiststeel 3
 sm_reverts__item_guillotine 1
 sm_reverts__item_gasjockey 1
 // Note: gas jockey set is enabled. note that the speed bonus can stack with the powerjack revert used here.
-sm_reverts__item_glovesru 2
+sm_reverts__item_glovesru 3
 sm_reverts__item_gunboats 1
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 1
@@ -63,12 +63,12 @@ sm_reverts__item_reserve 1
 sm_reverts__item_bison 1
 sm_reverts__item_rocketjmp 2
 sm_reverts__item_saharan 2
-sm_reverts__item_sandman 1
+sm_reverts__item_sandman 2
 sm_reverts__item_scottish 0
 // release scottish resistance was just awful to use
 sm_reverts__item_circuit 0
 // modern short circuit is the most powerful version
-sm_reverts__item_shortstop 1
+sm_reverts__item_shortstop 5
 sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -68,7 +68,7 @@ sm_reverts__item_scottish 0
 // release scottish resistance was just awful to use
 sm_reverts__item_circuit 0
 // modern short circuit is the most powerful version
-sm_reverts__item_shortstop 5
+sm_reverts__item_shortstop 3
 sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -86,7 +86,7 @@ sm_reverts__item_saharan 0
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 2
-sm_reverts__item_shortstop 4
+sm_reverts__item_shortstop 2
 sm_reverts__item_sodapop 2
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 0

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -21,7 +21,7 @@ sm_reverts__item_axtinguish 2
 sm_reverts__item_backburner 0
 sm_reverts__item_basejump 1
 sm_reverts__item_babyface 1
-sm_reverts__item_beggars 0
+sm_reverts__item_beggars 2
 sm_reverts__item_blackbox 1
 sm_reverts__item_bonk 1
 sm_reverts__item_booties 0
@@ -32,7 +32,7 @@ sm_reverts__item_bushwacka 0
 sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
-sm_reverts__item_carbine 1
+sm_reverts__item_carbine 2
 sm_reverts__item_cowmangler 0
 // pre-GM cow mangler had 4 shots, this is the closest
 sm_reverts__item_cozycamper 0

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1349,12 +1349,12 @@ public void OnGameFrame() {
 
 								switch (GetItemVariant(Wep_DeadRinger)) {
 									case 0: { // pre-GM
-									// when uncloaking, cloak is drained to 40%
+										// when uncloaking, cloak is drained to 40%
 
-									if (GetEntPropFloat(idx, Prop_Send, "m_flCloakMeter") > 40.0) {
-										SetEntPropFloat(idx, Prop_Send, "m_flCloakMeter", 40.0);
+										if (GetEntPropFloat(idx, Prop_Send, "m_flCloakMeter") > 40.0) {
+											SetEntPropFloat(idx, Prop_Send, "m_flCloakMeter", 40.0);
+										}
 									}
-								}
 									case 3: { // post-release
 										// fully drain meter when uncloaking
 
@@ -1363,7 +1363,6 @@ public void OnGameFrame() {
 										}
 									}
 								}
-
 							}
 						}
 
@@ -1939,9 +1938,9 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 4, 2067, 0.0); // attack minicrits and consumes burning
 				}
 				case 1: {
-			TF2Items_SetNumAttributes(itemNew, 5);
-			TF2Items_SetAttribute(itemNew, 0, 1, 1.00); // damage penalty
-			TF2Items_SetAttribute(itemNew, 1, 21, 0.50); // dmg penalty vs nonburning
+					TF2Items_SetNumAttributes(itemNew, 5);
+					TF2Items_SetAttribute(itemNew, 0, 1, 1.00); // damage penalty
+					TF2Items_SetAttribute(itemNew, 1, 21, 0.50); // dmg penalty vs nonburning
 					TF2Items_SetAttribute(itemNew, 2, 638, 1.0); // axtinguisher properties
 					TF2Items_SetAttribute(itemNew, 3, 772, 1.00); // single wep holster time increased
 					TF2Items_SetAttribute(itemNew, 4, 2067, 0.0); // attack minicrits and consumes burning
@@ -1950,7 +1949,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetNumAttributes(itemNew, 5);
 					TF2Items_SetAttribute(itemNew, 0, 5, 1.2); // fire rate penalty
 					TF2Items_SetAttribute(itemNew, 1, 20, 1.0); // crit vs burning players
-			TF2Items_SetAttribute(itemNew, 2, 772, 1.00); // single wep holster time increased
+					TF2Items_SetAttribute(itemNew, 2, 772, 1.00); // single wep holster time increased
 					TF2Items_SetAttribute(itemNew, 3, 773, 1.75); // single wep deploy time increased
 					TF2Items_SetAttribute(itemNew, 4, 2067, 0.0); // attack minicrits and consumes burning
 				}
@@ -2067,7 +2066,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 751: { if (ItemIsEnabled(Wep_CleanerCarbine)) {
 			switch (GetItemVariant(Wep_CleanerCarbine)) {
 				case 0: {
-			TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetNumAttributes(itemNew, 4);
 					TF2Items_SetAttribute(itemNew, 0, 5, 1.35); // 35% slower firing speed
 					TF2Items_SetAttribute(itemNew, 1, 31, 3.0); // 3 sec crits on kill
 					TF2Items_SetAttribute(itemNew, 2, 779, 0.0); // minicrit on charge
@@ -2472,7 +2471,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 1, 278, 1.50); // increase ball recharge time to 15s
 				}
 				default: {
-			TF2Items_SetNumAttributes(itemNew, 1);
+					TF2Items_SetNumAttributes(itemNew, 1);
 					TF2Items_SetAttribute(itemNew, 0, 278, 1.50); // increase ball recharge time to 15s
 				}
 			}
@@ -2562,10 +2561,10 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 2, 247, 1.0); // can deal charge impact damage at any range
 				}
 				default: {
-			TF2Items_SetNumAttributes(itemNew, 3);
-			TF2Items_SetAttribute(itemNew, 0, 64, 0.85); // dmg taken from blast reduced
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 64, 0.85); // dmg taken from blast reduced
 					TF2Items_SetAttribute(itemNew, 1, 249, 1.0); // remove +50% increase in charge recharge rate
-			TF2Items_SetAttribute(itemNew, 2, 247, 1.0); // can deal charge impact damage at any range
+					TF2Items_SetAttribute(itemNew, 2, 247, 1.0); // can deal charge impact damage at any range
 				}
 			}
 		}}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -558,6 +558,7 @@ public void OnPluginStart() {
 	ItemDefine("saharan", "Saharan_Release", CLASSFLAG_SPY, Set_Saharan);
 	ItemVariant(Set_Saharan, "Saharan_ExtraCloak");
 	ItemDefine("sandman", "Sandman_PreJI", CLASSFLAG_SCOUT, Wep_Sandman);
+	ItemVariant(Wep_Sandman, "Sandman_PreWAR");
 	ItemDefine("scottish", "Scottish_Release", CLASSFLAG_DEMOMAN, Wep_Scottish);
 	ItemDefine("circuit", "Circuit_PreMYM", CLASSFLAG_ENGINEER, Wep_ShortCircuit);
 	ItemVariant(Wep_ShortCircuit, "Circuit_PreGM");
@@ -2464,8 +2465,17 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			}
 		}}
 		case 44: { if (ItemIsEnabled(Wep_Sandman)) {
+			switch (GetItemVariant(Wep_Sandman)) {
+				case 1: {
+					TF2Items_SetNumAttributes(itemNew, 2);
+					TF2Items_SetAttribute(itemNew, 0, 125, -30.0); // -30 max health on wearer
+					TF2Items_SetAttribute(itemNew, 1, 278, 1.50); // increase ball recharge time to 15s
+				}
+				default: {
 			TF2Items_SetNumAttributes(itemNew, 1);
-			TF2Items_SetAttribute(itemNew, 0, 278, 1.50); //effect bar recharge rate increased attribute; this number increases ball recharge time from 10s to 15s
+					TF2Items_SetAttribute(itemNew, 0, 278, 1.50); // increase ball recharge time to 15s
+				}
+			}
 		}}
 		case 130: { if (ItemIsEnabled(Wep_Scottish)) {
 			TF2Items_SetNumAttributes(itemNew, 2);
@@ -3924,7 +3934,7 @@ Action SDKHookCB_OnTakeDamage(
 									stun_dur = (stun_dur + 2.0);
 								}
 
-								stun_fls = TF_STUNFLAGS_SMALLBONK;
+								stun_fls = GetItemVariant(Wep_Sandman) == 0 ? TF_STUNFLAGS_SMALLBONK : TF_STUNFLAGS_NORMALBONK;
 
 								if (stun_amt >= 1.0) {
 									// moonshot!
@@ -3948,6 +3958,12 @@ Action SDKHookCB_OnTakeDamage(
 								}
 
 								TF2_StunPlayer(victim, stun_dur, 0.5, stun_fls, attacker);
+
+								if (GetItemVariant(Wep_Sandman) == 1) {
+									// Pre-WAR Sandman stun victims receive 75% of damage dealt
+									// "dmg taken increased" is the only attribute of class "mult_dmgtaken"
+									TF2Attrib_AddCustomPlayerAttribute(victim, "dmg taken increased", 0.75, stun_dur);
+								}
 
 								players[victim].stunball_fix_time_bonk = GetGameTime();
 								players[victim].stunball_fix_time_wear = 0.0;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -561,6 +561,7 @@ public void OnPluginStart() {
 	ItemVariant(Wep_Shortstop, "Shortstop_PreMnvy");
 	ItemVariant(Wep_Shortstop, "Shortstop_PreGM_Shove");
 	ItemVariant(Wep_Shortstop, "Shortstop_PreGM");
+	ItemVariant(Wep_Shortstop, "Shortstop_Release");
 	ItemDefine("sodapop", "Sodapop_Pre2013", CLASSFLAG_SCOUT, Wep_SodaPopper);
 	ItemVariant(Wep_SodaPopper, "Sodapop_PreMYM");
 	ItemDefine("solemn", "Solemn_PreGM", CLASSFLAG_MEDIC, Wep_Solemn);
@@ -2424,6 +2425,14 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 1, 534, 1.40); // airblast vulnerability multiplier hidden
 					TF2Items_SetAttribute(itemNew, 2, 535, 1.40); // damage force increase hidden
 					TF2Items_SetAttribute(itemNew, 3, 128, 0.0); // disable provide_on_active so push force penalty is active at all times
+				}
+				case 4: {
+					// Release Shortstop
+					TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetAttribute(itemNew, 0, 182, 0.5); // On Hit: Slow target movement by 40% for 0.5s
+					TF2Items_SetAttribute(itemNew, 1, 241, 1.0); // reload time increased hidden
+					TF2Items_SetAttribute(itemNew, 2, 534, 1.00); // airblast vulnerability multiplier hidden
+					TF2Items_SetAttribute(itemNew, 3, 535, 1.00); // damage force increase hidden
 				}
 			}	
 		}}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -196,6 +196,7 @@ ConVar cvar_no_reverts_info_by_default;
 ConVar cvar_dropped_weapon_enable;
 #endif
 ConVar cvar_pre_toughbreak_switch;
+ConVar cvar_enable_shortstop_shove;
 ConVar cvar_ref_tf_airblast_cray;
 ConVar cvar_ref_tf_bison_tick_time;
 ConVar cvar_ref_tf_dropped_weapon_lifetime;
@@ -430,6 +431,7 @@ public void OnPluginStart() {
 #endif
 	cvar_no_reverts_info_by_default = CreateConVar("sm_reverts__no_reverts_info_on_spawn", "0", (PLUGIN_NAME ... " - Disable loadout change reverts info by default"), _, true, 0.0, true, 1.0);
 	cvar_pre_toughbreak_switch = CreateConVar("sm_reverts__pre_toughbreak_switch", "0", (PLUGIN_NAME ... " - Use pre-toughbreak weapon switch time (0.67 sec instead of 0.5 sec)"), _, true, 0.0, true, 1.0);
+	cvar_enable_shortstop_shove = CreateConVar("sm_reverts__enable_shortstop_shove", "0", (PLUGIN_NAME ... " - Enable alt-fire shove for reverted Shortstop"), _, true, 0.0, true, 1.0);
 
 #if defined MEMORY_PATCHES
 	cvar_dropped_weapon_enable.AddChangeHook(OnDroppedWeaponCvarChange);
@@ -563,9 +565,7 @@ public void OnPluginStart() {
 	ItemDefine("circuit", "Circuit_PreMYM", CLASSFLAG_ENGINEER, Wep_ShortCircuit);
 	ItemVariant(Wep_ShortCircuit, "Circuit_PreGM");
 	ItemVariant(Wep_ShortCircuit, "Circuit_Dec2013");
-	ItemDefine("shortstop", "Shortstop_PreMnvy_Shove", CLASSFLAG_SCOUT, Wep_Shortstop);
-	ItemVariant(Wep_Shortstop, "Shortstop_PreMnvy");
-	ItemVariant(Wep_Shortstop, "Shortstop_PreGM_Shove");
+	ItemDefine("shortstop", "Shortstop_PreMnvy", CLASSFLAG_SCOUT, Wep_Shortstop);
 	ItemVariant(Wep_Shortstop, "Shortstop_PreGM");
 	ItemVariant(Wep_Shortstop, "Shortstop_Release");
 	ItemDefine("sodapop", "Sodapop_Pre2013", CLASSFLAG_SCOUT, Wep_SodaPopper);
@@ -2487,14 +2487,14 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		}}
 		case 220: { if (ItemIsEnabled(Wep_Shortstop)) {
 			switch (GetItemVariant(Wep_Shortstop)) {
-				case 0, 1: {
+				case 0: {
 					// Pre-Manniversary Shortstop
 					TF2Items_SetNumAttributes(itemNew, 3);
 					TF2Items_SetAttribute(itemNew, 0, 241, 1.0); // reload time increased hidden
 					TF2Items_SetAttribute(itemNew, 1, 534, 1.00); // airblast vulnerability multiplier hidden
 					TF2Items_SetAttribute(itemNew, 2, 535, 1.00); // damage force increase hidden
 				}
-				case 2, 3: {
+				case 1: {
 					// Pre-Gun Mettle Shortstop
 					TF2Items_SetNumAttributes(itemNew, 4);
 					TF2Items_SetAttribute(itemNew, 0, 526, 1.20); // 20% bonus healing from all sources
@@ -2502,7 +2502,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 2, 535, 1.40); // damage force increase hidden
 					TF2Items_SetAttribute(itemNew, 3, 128, 0.0); // disable provide_on_active so push force penalty is active at all times
 				}
-				case 4: {
+				case 2: {
 					// Release Shortstop
 					TF2Items_SetNumAttributes(itemNew, 4);
 					TF2Items_SetAttribute(itemNew, 0, 182, 0.5); // On Hit: Slow target movement by 40% for 0.5s
@@ -5445,8 +5445,8 @@ MRESReturn DHookCallback_CTFWeaponBase_SecondaryAttack(int entity) {
 		}
 
 		if (
-			(GetItemVariant(Wep_Shortstop) == 1 ||
-			GetItemVariant(Wep_Shortstop) == 3) &&
+			ItemIsEnabled(Wep_Shortstop) &&
+			cvar_enable_shortstop_shove.BoolValue == false &&
 			StrEqual(class, "tf_weapon_handgun_scout_primary")
 		) {
 			// shortstop shove removal

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -436,6 +436,7 @@ public void OnPluginStart() {
 #if defined MEMORY_PATCHES
 	cvar_dropped_weapon_enable.AddChangeHook(OnDroppedWeaponCvarChange);
 #endif
+	cvar_enable_shortstop_shove.AddChangeHook(OnShortstopShoveCvarChange);
 
 	ItemDefine("airblast", "Airblast_PreJI", CLASSFLAG_PYRO, Feat_Airblast);
 	ItemDefine("airstrike", "Airstrike_PreTB", CLASSFLAG_SOLDIER, Wep_Airstrike);
@@ -816,6 +817,25 @@ public void OnDroppedWeaponLifetimeCvarChange(ConVar convar, const char[] oldVal
 }
 #endif
 
+public void OnShortstopShoveCvarChange(ConVar convar, const char[] oldValue, const char[] newValue) {
+	UpdateShortstopDescription();
+}
+
+void UpdateShortstopDescription() {
+	int i = Wep_Shortstop;
+	char shove_str[] = "_Shove";
+
+	for (int j = 0; j <= items[i].num_variants; j++) {
+		if (cvar_enable_shortstop_shove.BoolValue) {
+			if (StrContains(items_desc[i][j], shove_str) == -1) {
+				Format(items_desc[i][j], sizeof(items_desc[][]), "%s%s", items_desc[i][j], shove_str);
+			}
+		} else {
+			ReplaceString(items_desc[i][j], sizeof(items_desc[][]), shove_str, "");
+		}
+	}
+}
+
 public void OnConfigsExecuted() {
 #if defined MEMORY_PATCHES
 	ToggleMemoryPatchReverts(ItemIsEnabled(Wep_Disciplinary),Wep_Disciplinary);
@@ -830,6 +850,7 @@ public void OnConfigsExecuted() {
 #else
 	SetConVarMaybe(cvar_ref_tf_dropped_weapon_lifetime, "0", cvar_enable.BoolValue);
 #endif
+	UpdateShortstopDescription();
 }
 
 #if defined MEMORY_PATCHES

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -446,6 +446,7 @@ public void OnPluginStart() {
 	ItemVariant(Wep_Atomizer, "Atomizer_PreBM");
 	ItemDefine("axtinguish", "Axtinguisher_PreLW", CLASSFLAG_PYRO, Wep_Axtinguisher);
 	ItemVariant(Wep_Axtinguisher, "Axtinguisher_PreTB");
+	ItemVariant(Wep_Axtinguisher, "Axtinguisher_PreBM");
 	ItemDefine("backburner", "Backburner_PreHat", CLASSFLAG_PYRO, Wep_Backburner);
 	ItemVariant(Wep_Backburner, "Backburner_119");
 	ItemVariant(Wep_Backburner, "Backburner_Release");
@@ -453,6 +454,7 @@ public void OnPluginStart() {
 	ItemDefine("babyface", "BabyFace_PreGM", CLASSFLAG_SCOUT, Wep_BabyFace);
 	ItemVariant(Wep_BabyFace, "BabyFace_Release");
 	ItemDefine("beggars", "Beggars_Pre2013", CLASSFLAG_SOLDIER, Wep_Beggars);
+	ItemVariant(Wep_Beggars, "Beggars_PreTB");
 	ItemDefine("blackbox", "BlackBox_PreGM", CLASSFLAG_SOLDIER, Wep_BlackBox);
 	ItemDefine("bonk", "Bonk_PreJI", CLASSFLAG_SCOUT, Wep_Bonk);
 	ItemDefine("booties", "Booties_PreMYM", CLASSFLAG_DEMOMAN, Wep_Booties);
@@ -464,6 +466,7 @@ public void OnPluginStart() {
 	ItemDefine("targe", "Targe_PreTB", CLASSFLAG_DEMOMAN, Wep_CharginTarge);
 	ItemDefine("claidheamh", "Claidheamh_PreTB", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
 	ItemDefine("carbine", "Carbine_Release", CLASSFLAG_SNIPER, Wep_CleanerCarbine);
+	ItemVariant(Wep_CleanerCarbine, "Carbine_PreTB");
 	ItemDefine("cowmangler", "CowMangler_Release", CLASSFLAG_SOLDIER, Wep_CowMangler);
 	ItemVariant(Wep_CowMangler, "CowMangler_Pre2013");
 #if defined MEMORY_PATCHES
@@ -506,6 +509,7 @@ public void OnPluginStart() {
 	ItemDefine("guillotine", "Guillotine_PreJI", CLASSFLAG_SCOUT, Wep_Cleaver);
 	ItemDefine("gasjockey", "GasJockey_Release", CLASSFLAG_PYRO, Set_GasJockey);
 	ItemDefine("glovesru", "GlovesRU_PreTB", CLASSFLAG_HEAVY, Wep_GRU);
+	ItemVariant(Wep_GRU, "GlovesRU_PreJI");
 	ItemVariant(Wep_GRU, "GlovesRU_PrePyro");
 	ItemDefine("gunboats", "Gunboats_Release", CLASSFLAG_SOLDIER, Wep_Gunboats);
 	ItemDefine("zatoichi", "Zatoichi_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_DEMOMAN, Wep_Zatoichi);
@@ -567,6 +571,7 @@ public void OnPluginStart() {
 	ItemDefine("solemn", "Solemn_PreGM", CLASSFLAG_MEDIC, Wep_Solemn);
 	ItemDefine("spdelivery", "SpDelivery_Release", CLASSFLAG_SCOUT, Set_SpDelivery);
 	ItemDefine("splendid", "Splendid_PreTB", CLASSFLAG_DEMOMAN, Wep_SplendidScreen);
+	ItemVariant(Wep_SplendidScreen, "Splendid_Release");
 	ItemDefine("spycicle", "SpyCicle_PreGM", CLASSFLAG_SPY, Wep_Spycicle);
 	ItemDefine("stkjumper", "StkJumper_Pre2013", CLASSFLAG_DEMOMAN, Wep_StickyJumper);
 	ItemVariant(Wep_StickyJumper, "StkJumper_Pre2013_Intel");
@@ -1229,8 +1234,8 @@ public void OnGameFrame() {
 								ammo = GetEntProp(idx, Prop_Send, "m_iAmmo", 4, 1);
 
 								if (
-									ItemIsEnabled(Wep_Beggars) &&
-									players[idx].beggars_ammo == 3 &&
+									GetItemVariant(Wep_Beggars) == 0 &&
+									players[idx].beggars_ammo >= 3 &&
 									clip == (players[idx].beggars_ammo - 1) &&
 									rocket_create_entity == -1 &&
 									(rocket_create_frame + 1) == GetGameTickCount() &&
@@ -1912,12 +1917,33 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				
 		}}
 		case 38, 457, 1000: { if (ItemIsEnabled(Wep_Axtinguisher)) {
+			switch (GetItemVariant(Wep_Axtinguisher)) {
+				case 0: {
+					TF2Items_SetNumAttributes(itemNew, 5);
+					TF2Items_SetAttribute(itemNew, 0, 1, 1.00); // damage penalty
+					TF2Items_SetAttribute(itemNew, 1, 20, 1.0); // crit vs burning players
+					TF2Items_SetAttribute(itemNew, 2, 21, 0.50); // dmg penalty vs nonburning
+					TF2Items_SetAttribute(itemNew, 3, 772, 1.00); // single wep holster time increased
+					TF2Items_SetAttribute(itemNew, 4, 2067, 0.0); // attack minicrits and consumes burning
+				}
+				case 1: {
 			TF2Items_SetNumAttributes(itemNew, 5);
 			TF2Items_SetAttribute(itemNew, 0, 1, 1.00); // damage penalty
 			TF2Items_SetAttribute(itemNew, 1, 21, 0.50); // dmg penalty vs nonburning
+					TF2Items_SetAttribute(itemNew, 2, 638, 1.0); // axtinguisher properties
+					TF2Items_SetAttribute(itemNew, 3, 772, 1.00); // single wep holster time increased
+					TF2Items_SetAttribute(itemNew, 4, 2067, 0.0); // attack minicrits and consumes burning
+				}
+				case 2: {
+					TF2Items_SetNumAttributes(itemNew, 5);
+					TF2Items_SetAttribute(itemNew, 0, 5, 1.2); // fire rate penalty
+					TF2Items_SetAttribute(itemNew, 1, 20, 1.0); // crit vs burning players
 			TF2Items_SetAttribute(itemNew, 2, 772, 1.00); // single wep holster time increased
-			TF2Items_SetAttribute(itemNew, 3, 2067, 0.0); // attack minicrits and consumes burning
-			TF2Items_SetAttribute(itemNew, 4, GetItemVariant(Wep_Axtinguisher) == 1 ? 638 : 20, 1.0); // axtinguisher properties, crit on burning players
+					TF2Items_SetAttribute(itemNew, 3, 773, 1.75); // single wep deploy time increased
+					TF2Items_SetAttribute(itemNew, 4, 2067, 0.0); // attack minicrits and consumes burning
+				}
+			}
+			
 		}}
 		case 772: { if (ItemIsEnabled(Wep_BabyFace)) {
 			switch (GetItemVariant(Wep_BabyFace)) {
@@ -2027,11 +2053,22 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 0, 103, 1.50); // projectile speed increased
 		}}
 		case 751: { if (ItemIsEnabled(Wep_CleanerCarbine)) {
+			switch (GetItemVariant(Wep_CleanerCarbine)) {
+				case 0: {
 			TF2Items_SetNumAttributes(itemNew, 4);
-			TF2Items_SetAttribute(itemNew, 0, 31, 3.0); // crit on kill
-			TF2Items_SetAttribute(itemNew, 1, 779, 0.0); // minicrit on charge
-			TF2Items_SetAttribute(itemNew, 2, 780, 0.0); // gain charge on hit
-			TF2Items_SetAttribute(itemNew, 3, 5, 1.35); // 35% firing speed penalty
+					TF2Items_SetAttribute(itemNew, 0, 5, 1.35); // 35% slower firing speed
+					TF2Items_SetAttribute(itemNew, 1, 31, 3.0); // 3 sec crits on kill
+					TF2Items_SetAttribute(itemNew, 2, 779, 0.0); // minicrit on charge
+					TF2Items_SetAttribute(itemNew, 3, 780, 0.0); // gain charge on hit
+				}
+				case 1: {
+					TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetAttribute(itemNew, 0, 5, 1.35); // 35% slower firing speed
+					TF2Items_SetAttribute(itemNew, 1, 613, 8.0); // 8 sec minicrits on kill
+					TF2Items_SetAttribute(itemNew, 2, 779, 0.0); // minicrit on charge
+					TF2Items_SetAttribute(itemNew, 3, 780, 0.0); // gain charge on hit
+				}
+			}
 		}}
 		case 327: { if (ItemIsEnabled(Wep_Claidheamh)) {
 			bool swords = ItemIsEnabled(Feat_Sword);
@@ -2190,7 +2227,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 239, 1084, 1100: { if (ItemIsEnabled(Wep_GRU)) {
 			switch (GetItemVariant(Wep_GRU)) {
 				case 0: {
-					// Pre-Tough Break version of the GRU
+					// Pre-Tough Break
 					TF2Items_SetNumAttributes(itemNew, 4);
 					TF2Items_SetAttribute(itemNew, 0, 1, 0.75); // damage penalty
 					TF2Items_SetAttribute(itemNew, 1, 414, 3.0); // self mark for death
@@ -2198,7 +2235,14 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 3, 855, 0.0); // mod maxhealth drain rate
 				}
 				case 1: {
-					// Pre-Pyromania version of the GRU
+					// Pre-Jungle Inferno
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 1, 0.75); // damage penalty
+					TF2Items_SetAttribute(itemNew, 1, 414, 3.0); // self mark for death
+					TF2Items_SetAttribute(itemNew, 2, 855, 0.0); // mod maxhealth drain rate
+				}
+				case 2: {
+					// Pre-Pyromania
 					TF2Items_SetNumAttributes(itemNew, 4);
 					TF2Items_SetAttribute(itemNew, 0, 1, 0.50); // 50% damage penalty
 					TF2Items_SetAttribute(itemNew, 1, 191, -6.0); // drain 6HP/s while actve; small knockback while active is supposed to happen (called GRU jumping)
@@ -2482,10 +2526,20 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 0, 5, 1.0); // fire rate penalty
 		}}
 		case 406: { if (ItemIsEnabled(Wep_SplendidScreen)) {
+			switch (GetItemVariant(Wep_SplendidScreen)) {
+				case 1: {
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 60, 0.75); // dmg taken from fire reduced
+					TF2Items_SetAttribute(itemNew, 1, 249, 1.0); // remove +50% increase in charge recharge rate
+					TF2Items_SetAttribute(itemNew, 2, 247, 1.0); // can deal charge impact damage at any range
+				}
+				default: {
 			TF2Items_SetNumAttributes(itemNew, 3);
 			TF2Items_SetAttribute(itemNew, 0, 64, 0.85); // dmg taken from blast reduced
-			TF2Items_SetAttribute(itemNew, 1, 249, 1.00); // remove +50% increase in charge recharge rate
+					TF2Items_SetAttribute(itemNew, 1, 249, 1.0); // remove +50% increase in charge recharge rate
 			TF2Items_SetAttribute(itemNew, 2, 247, 1.0); // can deal charge impact damage at any range
+				}
+			}
 		}}
 		case 649: { if (ItemIsEnabled(Wep_Spycicle)) {
 			TF2Items_SetNumAttributes(itemNew, 1);
@@ -4081,8 +4135,7 @@ Action SDKHookCB_OnTakeDamage(
 					// other shields can only bash at the end of a charge
 					if (player_weapons[attacker][Wep_SplendidScreen] == false)
 					{
-						charge = GetEntPropFloat(attacker, Prop_Send, "m_flChargeMeter");
-						if (charge > 40.0)
+						if (GetEntPropFloat(attacker, Prop_Send, "m_flChargeMeter") > 40.0)
 						{
 							return Plugin_Handled;
 						}

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -484,6 +484,10 @@
 	{
 		"fi"	"Ennen Tough Breakiä: kriittisiä osumia takaa, minikriittisiä osumia edestä, ei nopeuslisää taposta"
 	}
+	"Axtinguisher_PreBM"
+	{
+		"fi"	"Ennen Blue Moonia: kriittisiä osumia palaviin pelaajiin, 75%% pidempi esiinvetoaika, 20%% hitaampi lyöntinopeus, ei nopeuslisää taposta"
+	}
 	"Backburner_PreHat"
 	{
 		"fi"	"Hatless-päivitys versio: 10%% vahinkobonus"
@@ -511,6 +515,10 @@
 	"Beggars_Pre2013"
 	{
 		"fi"	"Ennen vuotta 2013: ei räjähdysalueheikkoutta, liialliset lataukset eivät vähennä lipasta"
+	}
+	"Beggars_PreTB"
+	{
+		"fi"	"Ennen Tough Breakiä: ei räjähdysalueheikkoutta"
 	}
 	"BlackBox_PreGM"
 	{
@@ -546,7 +554,7 @@
 	}
 	"Targe_PreTB"
 	{
-		"fi"	"Ennen Tough Breakiä: 40%% räjähdyssietoa, jälkipolttoimmuniteetti, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
+		"fi"	"Ennen Tough Breakiä: 40%% räjähdyssietoa, jälkipolttoimmuniteetti, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko vain ryntäyksen lopussa"
 	}
 	"Claidheamh_PreTB"
 	{
@@ -554,7 +562,11 @@
 	}
 	"Carbine_Release"
 	{
-		"fi"	"Julkaisuversio: tapot antavat 3 sekunnin kriittisyystehosteen, 35%% hitaampi tulitusnopeus (25%%:sta)"
+		"fi"	"Julkaisuversio: tapot antavat kriittisiä 3 sekunniksi, 35%% hitaampi tulitusnopeus (25%%:sta)"
+	}
+	"Carbine_PreTB"
+	{
+		"fi"	"Ennen Tough Breakiä: tapot antavat minikriittisiä 8 sekunniksi, 35%% hitaampi tulitusnopeus (25%%:sta)"
 	}
 	"CowMangler_Release"
 	{
@@ -606,7 +618,7 @@
 	}
 	"Ringer_PreGM"
 	{
-		"fi"	"Ennen Gun Mettleä: voi kerätä ammuksia, 90%% vahinkosieto jopa 6,5 sekunniksi (vahinko vähentää aikaa), ei nopeuslisää"
+		"fi"	"Ennen Gun Mettleä: voi kerätä ammuksia, 90%% vahingonsieto jopa 6,5 sekunniksi (vahinko vähentää aikaa), ei nopeuslisää"
 	}
 	"Ringer_PreJI"
 	{
@@ -615,6 +627,10 @@
 	"Ringer_PreTB"
 	{
 		"fi"	"Ennen Tough Breakiä: samat perusominaisuudet, mutta 50%% ensimmäisen osuman vahinkosieto ja voi täyttää verhoutumismittaria ammuksilla näkyvänä (35%% vähemmän)"
+	}
+	"Ringer_PostRelease"
+	{
+		"fi"	"Julkaisun jälkeinen versio: 90%% vahingonsieto 6,5 sekunniksi, ei nopeuslisää, aikainen verhoistapoistuminen tyhjentää verhoutumismittarin"
 	}
 	"Degreaser_PreTB"
 	{
@@ -687,6 +703,10 @@
 	"GlovesRU_PreTB"
 	{
 		"fi"	"Ennen Tough Breakiä: ei laske terveyttä, ei poislaittoheikkoutta, merkkaa kuolemaan, -25%% vahinkoa"
+	}
+	"GlovesRU_PreJI"
+	{
+		"fi"	"Ennen Jungle Infernoa: ei laske terveyttä, merkkaa kuolemaan, -25%% vahinkoa"
 	}
 	"GlovesRU_PrePyro"
 	{
@@ -848,6 +868,10 @@
 	{
 		"fi"	"Ennen Jungle Infernoa: pallo-osumat tainnuttavat pelaajia, 15 sekunnin latausaika"
 	}
+	"Sandman_PreWAR"
+	{
+		"fi"	"Ennen WAR!-päivitystä: pallo-osumat tainnuttavat pelaajat täysin, tainnutusuhrit saavat 75%% vahinkoa, -30 maksimiterveys, 15 sekunnin latausaika"
+	}
 	"Scottish_Release"
 	{
 		"fi"	"Julkaisuversio: 0,4s hitaampi viritysaika (0,8:sta), ei tulitusnopeusbonusta"
@@ -870,7 +894,7 @@
 	}
 	"Shortstop_PreMnvy"
 	{
-		"fi"	"Ennen Manniversary-päivitystä: nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa, ei tönäisyä"
+		"fi"	"Ennen Manniversary-päivitystä: nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
 	}
 	"Shortstop_PreGM_Shove"
 	{
@@ -878,7 +902,11 @@
 	}
 	"Shortstop_PreGM"
 	{
-		"fi"	"Ennen Gun Mettleä: +20%% parantumisbonus käytössä, +40%% työntövoima (passiivinen), jakaa ammukset pistoolin kanssa, ei tönäisyä"
+		"fi"	"Ennen Gun Mettleä: +20%% parantumisbonus käytössä, +40%% työntövoima (passiivinen), jakaa ammukset pistoolin kanssa"
+	}
+	"Shortstop_Release"
+	{
+		"fi"	"Julkaisuversio: hidasta kohde 40%%:lla 0,5 sekunniksi, nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
 	}
 	"Sodapop_Pre2013"
 	{
@@ -898,7 +926,11 @@
 	}
 	"Splendid_PreTB"
 	{
-		"fi"	"Ennen Tough Breakiä: 15%% räjähdyssieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko kaikilta etäisyyksiltä"
+		"fi"	"Ennen Tough Breakiä: 15%% räjähdyssieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
+	}
+	"Splendid_Release"
+	{
+		"fi"	"Julkaisuversio: 25%% tulensieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
 	}
 	"SpyCicle_PreGM"
 	{
@@ -934,7 +966,7 @@
 	}
 	"Turner_PreTB"
 	{
-		"fi"	"Ennen Tough Breakiä: voi tehdä kriittisiä osumia, 25%% räjähdys- ja tulisieto, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
+		"fi"	"Ennen Tough Breakiä: voi tehdä kriittisiä osumia, 25%% räjähdys- ja tulisieto, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko vain ryntäyksen lopussa"
 	}
 	"Tomislav_PrePyro"
 	{

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -894,7 +894,7 @@
 	}
 	"Shortstop_PreMnvy"
 	{
-		"fi"	"Ennen Manniversary-päivitystä: nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
+		"fi"	"Ennen Manniversary-päivitystä: nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa, ei tönäisyä"
 	}
 	"Shortstop_PreGM_Shove"
 	{
@@ -902,11 +902,15 @@
 	}
 	"Shortstop_PreGM"
 	{
-		"fi"	"Ennen Gun Mettleä: +20%% parantumisbonus käytössä, +40%% työntövoima (passiivinen), jakaa ammukset pistoolin kanssa"
+		"fi"	"Ennen Gun Mettleä: +20%% parantumisbonus käytössä, +40%% työntövoima (passiivinen), jakaa ammukset pistoolin kanssa, ei tönäisyä"
+	}
+	"Shortstop_Release_Shove"
+	{
+		"fi"	"Julkaisuversio: hidasta kohde 40%%:lla 0,5 sekunniksi, nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
 	}
 	"Shortstop_Release"
 	{
-		"fi"	"Julkaisuversio: hidasta kohde 40%%:lla 0,5 sekunniksi, nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
+		"fi"	"Julkaisuversio: hidasta kohde 40%%:lla 0,5 sekunniksi, nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa, ei tönäisyä"
 	}
 	"Sodapop_Pre2013"
 	{

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -930,11 +930,11 @@
 	}
 	"Splendid_PreTB"
 	{
-		"fi"	"Ennen Tough Breakiä: 15%% räjähdyssieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
+		"fi"	"Ennen Tough Breakiä: 15%% räjähdyssieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko kaikilta etäisyyksiltä"
 	}
 	"Splendid_Release"
 	{
-		"fi"	"Julkaisuversio: 25%% tulensieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa"
+		"fi"	"Julkaisuversio: 25%% tulensieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko kaikilta etäisyyksiltä"
 	}
 	"SpyCicle_PreGM"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -926,7 +926,7 @@
 	}
 	"Splendid_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal"
+		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal, bash dmg at any range"
 	}
 	"Splendid_Release"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -890,7 +890,7 @@
 	}
 	"Shortstop_PreMnvy"
 	{
-		"en"	"Reverted to pre-Manniversary, fast reload, no push force penalty, shares pistol ammo"
+		"en"	"Reverted to pre-Manniversary, fast reload, no push force penalty, shares pistol ammo, no shove"
 	}
 	"Shortstop_PreGM_Shove"
 	{
@@ -898,11 +898,15 @@
 	}
 	"Shortstop_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo"
+		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo, no shove"
+	}
+	"Shortstop_Release_Shove"
+	{
+		"en"	"Reverted to release, slow target by 40%% for 0.5s, fast reload, no push force penalty, shares pistol ammo; modern shove is kept"
 	}
 	"Shortstop_Release"
 	{
-		"en"	"Reverted to release, slow target by 40%% for 0.5s, fast reload, no push force penalty, shares pistol ammo"
+		"en"	"Reverted to release, slow target by 40%% for 0.5s, fast reload, no push force penalty, shares pistol ammo, no shove"
 	}
 	"Sodapop_Pre2013"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -930,7 +930,7 @@
 	}
 	"Splendid_Release"
 	{
-		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal"
+		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal, bash dmg at any range"
 	}
 	"SpyCicle_PreGM"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -480,6 +480,10 @@
 	{
 		"en"	"Reverted to pre-toughbreak, crits from behind, minicrits from front, no speedboost on kill"
 	}
+	"Axtinguisher_PreBM"
+	{
+		"en"	"Reverted to pre-bluemoon, crit vs burning players, 75%% longer deploy time, 20%% slower swing rate, no speedboost on kill"
+	}
 	"Backburner_PreHat"
 	{
 		"en"	"Reverted to Hatless update, +10%% damage bonus"
@@ -507,6 +511,10 @@
 	"Beggars_Pre2013"
 	{
 		"en"	"Reverted to pre-2013, no radius penalty, misfires don't remove ammo clip"
+	}
+	"Beggars_PreTB"
+	{
+		"en"	"Reverted to pre-toughbreak, no radius penalty"
 	}
 	"BlackBox_PreGM"
 	{
@@ -542,7 +550,7 @@
 	}
 	"Targe_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, 40%% blast resistance, afterburn immunity, crit after bash, no debuff removal"
+		"en"	"Reverted to pre-toughbreak, 40%% blast resistance, afterburn immunity, crit after bash, no debuff removal, bash dmg at 60%% depleted"
 	}
 	"Claidheamh_PreTB"
 	{
@@ -551,6 +559,10 @@
 	"Carbine_Release"
 	{
 		"en"	"Reverted to release, crits for 3 seconds on kill, 35%% slower fire rate (from 25%%)"
+	}
+	"Carbine_PreTB"
+	{
+		"en"	"Reverted to pre-toughbreak, minicrits for 8 seconds on kill, 35%% slower fire rate (from 25%%)"
 	}
 	"CowMangler_Release"
 	{
@@ -611,6 +623,10 @@
 	"Ringer_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, same modern stats but 50%% initial dmg resist, can pick up ammo while uncloaked, 35%% less cloak from ammo boxes"
+	}
+	"Ringer_PostRelease"
+	{
+		"en"	"Reverted to post-release, 90%% dmg resist for 6.5s, no speedboost, full drain on early decloak"
 	}
 	"Degreaser_PreTB"
 	{
@@ -683,6 +699,10 @@
 	"GlovesRU_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, no health drain or holster penalty, marks for death, -25%% damage"
+	}
+	"GlovesRU_PreJI"
+	{
+		"en"	"Reverted to pre-inferno, no health drain, marks for death, -25%% damage"
 	}
 	"GlovesRU_PrePyro"
 	{
@@ -844,6 +864,10 @@
 	{
 		"en"	"Reverted to pre-inferno, stuns players on hit again, 15 sec ball recharge time"
 	}
+	"Sandman_PreWAR"
+	{
+		"en"	"Reverted to pre-WAR! Update, full stuns, stun victims receive 75%% damage, -30 max health, 15 sec ball recharge time"
+	}
 	"Scottish_Release"
 	{
 		"en"	"Reverted to release, 0.4 arm time penalty (from 0.8), no fire rate bonus"
@@ -898,7 +922,11 @@
 	}
 	"Splendid_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal, bash dmg at any range"
+		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal"
+	}
+	"Splendid_Release"
+	{
+		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal"
 	}
 	"SpyCicle_PreGM"
 	{
@@ -934,7 +962,7 @@
 	}	
 	"Turner_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, can deal full crits, 25%% blast and fire resist, crit after bash, no debuff removal"
+		"en"	"Reverted to pre-toughbreak, can deal full crits, 25%% blast and fire resist, crit after bash, no debuff removal, bash dmg at 60%% depleted"
 	}
 	"Tomislav_PrePyro"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -890,7 +890,7 @@
 	}
 	"Shortstop_PreMnvy"
 	{
-		"en"	"Reverted to pre-Manniversary, fast reload, no push force penalty, shares pistol ammo, no shove"
+		"en"	"Reverted to pre-Manniversary, fast reload, no push force penalty, shares pistol ammo"
 	}
 	"Shortstop_PreGM_Shove"
 	{
@@ -898,11 +898,11 @@
 	}
 	"Shortstop_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo, no shove"
+		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo"
 	}
 	"Shortstop_Release"
 	{
-		"en"	"Reverted to release, slow target by 40%% for 0.5s, fast reload, no push force penalty, shares pistol ammo; modern shove is kept"
+		"en"	"Reverted to release, slow target by 40%% for 0.5s, fast reload, no push force penalty, shares pistol ammo"
 	}
 	"Sodapop_Pre2013"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -876,6 +876,10 @@
 	{
 		"en"	"Reverted to pre-gunmettle, +20%% bonus healing from health packs while active, +40%% knockback vuln at all times, shares pistol ammo, no shove"
 	}
+	"Shortstop_Release"
+	{
+		"en"	"Reverted to release, slow target by 40%% for 0.5s, fast reload, no push force penalty, shares pistol ammo; modern shove is kept"
+	}
 	"Sodapop_Pre2013"
 	{
 		"en"	"Reverted to pre-Smissmas 2013, run to build hype and auto gain minicrits"


### PR DESCRIPTION
### Summary of changes
pre-bm axtinguisher
pre-tb beggars
pre-tb carbine
post-release deadringer
pre-ji gru
pre-war sandman
release shortstop
release splendid

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway

### Other Info
Reword targe and turner descriptions that they can only bash dmg at 60% depleted (near-end of charge)
Remove shortstop variants with shove and replace with cvar, ~also removed mentioning of shove from phrases~
Do shove removal in DHook