### PR TITLE
(Reverts) Add purple smoke for double jumps for Pre-Inferno Atomizer

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1075,21 +1075,27 @@ public void OnGameFrame() {
 
 							if (
 								airdash_limit_new == 2 &&
-								players[idx].scout_airdash_count == 2 &&
 								ItemIsEnabled(Wep_Atomizer)
 							) {
-								// atomizer global jump
-								if (GetItemVariant(Wep_Atomizer) == 0) {
-									SDKHooks_TakeDamage(idx, idx, idx, 10.0, (DMG_BULLET|DMG_PREVENT_PHYSICS_FORCE), -1, NULL_VECTOR, NULL_VECTOR);
+								if (
+									GetItemVariant(Wep_Atomizer) == 0 ||
+									(GetItemVariant(Wep_Atomizer) == 1 && players[idx].scout_airdash_count == 2)
+								) {
+									// emit purple smoke (still shows white smoke too but good enough for now)
+									GetEntPropVector(idx, Prop_Send, "m_vecOrigin", pos1);
+									ParticleShowSimple("doublejump_puff_alt", pos1);
 								}
 
-								// emit purple smoke (still shows white smoke too but good enough for now)
-								GetEntPropVector(idx, Prop_Send, "m_vecOrigin", pos1);
-								ParticleShowSimple("doublejump_puff_alt", pos1);
+								if (players[idx].scout_airdash_count == 2) {
+									// atomizer global jump
+									if (GetItemVariant(Wep_Atomizer) == 0) {
+										SDKHooks_TakeDamage(idx, idx, idx, 10.0, (DMG_BULLET|DMG_PREVENT_PHYSICS_FORCE), -1, NULL_VECTOR, NULL_VECTOR);
+									}
 
-								if (airdash_limit_new > airdash_limit_old) {
-									// only play sound if the game doesn't play it
-									EmitSoundToAll("misc/banana_slip.wav", idx, SNDCHAN_AUTO, 30, (SND_CHANGEVOL|SND_CHANGEPITCH), 1.0, 100);
+									if (airdash_limit_new > airdash_limit_old) {
+										// only play sound if the game doesn't play it
+										EmitSoundToAll("misc/banana_slip.wav", idx, SNDCHAN_AUTO, 30, (SND_CHANGEVOL|SND_CHANGEPITCH), 1.0, 100);
+									}	
 								}
 							}
 						} else {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4499,7 +4499,8 @@ Action SDKHookCB_OnTakeDamageAlive(
 				((ItemIsEnabled(Wep_BrassBeast) && player_weapons[victim][Wep_BrassBeast]) ||
 				(GetItemVariant(Wep_Natascha) == 0 && player_weapons[victim][Wep_Natascha])) &&
 				TF2_IsPlayerInCondition(victim, TFCond_Slowed) &&
-				TF2_GetPlayerClass(victim) == TFClass_Heavy
+				TF2_GetPlayerClass(victim) == TFClass_Heavy &&
+				TF2Attrib_HookValueInt(0, "mod_pierce_resists_absorbs", weapon) == 0 // Don't resist if weapon pierces resists (vanilla Enforcer)
 			) {
 				// Brass Beast damage resistance when spun up
 

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4502,7 +4502,7 @@ Action SDKHookCB_OnTakeDamageAlive(
 				TF2_GetPlayerClass(victim) == TFClass_Heavy &&
 				TF2Attrib_HookValueInt(0, "mod_pierce_resists_absorbs", weapon) == 0 // Don't resist if weapon pierces resists (vanilla Enforcer)
 			) {
-				// Brass Beast damage resistance when spun up
+				// Brass Beast/Natascha (pre-MyM) damage resistance when spun up
 
 				// play damage resist sound
 				EmitGameSoundToAll("Player.ResistanceLight", victim);

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -658,15 +658,15 @@
 	}
 	"Equalizer_PrePyro"
 	{
-		"fi"	"Ennen Pyromaniaa: sulautettu takaisin yhteen, estää parannuksen, ei merkkaa kuolemaan; tekee 107 vahinkoa, kun terveys on 1"
+		"fi"	"Ennen Pyromaniaa: sulautettu takaisin yhteen, aseen ollessa aktiivisena: estää parannuksen, ei voi kutsua Mediciä, ei merkkaa kuolemaan; tekee 107 vahinkoa, kun terveys on 1"
 	}
 	"Equalizer_PreHat"
 	{
-		"fi"	"Ennen Hatless-päivitystä: sulautettu takaisin yhteen, estää parannuksen, ei merkkaa kuolemaan; tekee 113 vahinkoa, kun terveys on 1"
+		"fi"	"Ennen Hatless-päivitystä: sulautettu takaisin yhteen, aseen ollessa aktiivisena: estää parannuksen, ei voi kutsua Mediciä, ei merkkaa kuolemaan; tekee 113 vahinkoa, kun terveys on 1"
 	}
 	"Equalizer_Release"
 	{
-		"fi"	"Julkaisuversio: sulautettu takaisin yhteen, estää parannuksen, ei merkkaa kuolemaan; tekee 162 vahinkoa, kun terveys on 1"
+		"fi"	"Julkaisuversio: sulautettu takaisin yhteen, aseen ollessa aktiivisena: estää parannuksen, ei voi kutsua Mediciä, ei merkkaa kuolemaan; tekee 162 vahinkoa, kun terveys on 1"
 	}
 	"Eviction_PreJI"
 	{
@@ -890,7 +890,7 @@
 	}
 	"Shortstop_PreMnvy_Shove"
 	{
-		"fi"	"Ennen Manniversary-päivitystä: nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
+		"fi"	"Ennen Manniversary-päivitystä: nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa; tönäisy on säilytetty"
 	}
 	"Shortstop_PreMnvy"
 	{
@@ -898,15 +898,15 @@
 	}
 	"Shortstop_PreGM_Shove"
 	{
-		"fi"	"Ennen Gun Mettleä: +20%% parantumisbonus käytössä, +40%% työntövoima (passiivinen), jakaa ammukset pistoolin kanssa"
+		"fi"	"Ennen Gun Mettleä: +20%% bonusparannusta terveyspakkauksista käytössä, +40%% passiivinen työntövoima, jakaa ammukset pistoolin kanssa; tönäisy on säilytetty"
 	}
 	"Shortstop_PreGM"
 	{
-		"fi"	"Ennen Gun Mettleä: +20%% parantumisbonus käytössä, +40%% työntövoima (passiivinen), jakaa ammukset pistoolin kanssa, ei tönäisyä"
+		"fi"	"Ennen Gun Mettleä: +20%% bonusparannusta terveyspakkauksista käytössä, +40%% passiivinen työntövoima, jakaa ammukset pistoolin kanssa, ei tönäisyä"
 	}
 	"Shortstop_Release_Shove"
 	{
-		"fi"	"Julkaisuversio: hidasta kohde 40%%:lla 0,5 sekunniksi, nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa"
+		"fi"	"Julkaisuversio: hidasta kohde 40%%:lla 0,5 sekunniksi, nopea lataus, ei lisättyä työntövoimaa, jakaa ammukset pistoolin kanssa; tönäisy on säilytetty"
 	}
 	"Shortstop_Release"
 	{


### PR DESCRIPTION
### Summary of changes
historical accuracy
from tf2 wiki old revision:
> When performing a double or triple jump with the Atomizer equipped, a cloud of purple smoke will trail behind the Scout, as opposed to the normal white cloud.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway

### Other Info
update finnish locale
Reverted Brass Beast and Natascha don't resist vanilla Enforcer