### PR TITLE
(Reverts) Remove clientside speed boost sound for reverted Dead Ringer

### DIFF
--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -14,7 +14,7 @@ sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
 sm_reverts__item_basejump 1
 sm_reverts__item_babyface 1
-sm_reverts__item_beggars 1
+sm_reverts__item_beggars 2
 sm_reverts__item_blackbox 1
 sm_reverts__item_bonk 1
 sm_reverts__item_booties 1

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -27,7 +27,7 @@ sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 1
 sm_reverts__item_dalokohsbar 1
 sm_reverts__item_darwin 2
-sm_reverts__item_ringer 1
+sm_reverts__item_ringer 4
 sm_reverts__item_degreaser 1
 sm_reverts__item_disciplinary 1
 sm_reverts__item_dragonfury 1
@@ -72,7 +72,7 @@ sm_reverts__item_shortstop 3
 sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
-sm_reverts__item_splendid 1
+sm_reverts__item_splendid 2
 sm_reverts__item_spycicle 1
 sm_reverts__item_stkjumper 2
 sm_reverts__item_sleeper 3

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -27,7 +27,7 @@ sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 1
 sm_reverts__item_dalokohsbar 1
 sm_reverts__item_darwin 2
-sm_reverts__item_ringer 4
+sm_reverts__item_ringer 1
 sm_reverts__item_degreaser 1
 sm_reverts__item_disciplinary 1
 sm_reverts__item_dragonfury 1

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1888,8 +1888,10 @@ public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &pro
 			TF2_GetPlayerClass(client) == TFClass_Spy
 		) {
 			// prevent speed boost being applied on feign death
+			// handle feign buffs ourselves
 			if (
-				condition == TFCond_SpeedBuffAlly &&
+				(condition == TFCond_SpeedBuffAlly ||
+				condition == TFCond_DeadRingered) &&
 				players[client].feign_ready_tick == GetGameTickCount()
 			) {
 				return Plugin_Handled;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1370,7 +1370,6 @@ public void OnGameFrame() {
 								switch (GetItemVariant(Wep_DeadRinger)) {
 									case 0, 3: {
 										players[idx].spy_under_feign_buffs = true;
-										TF2_RemoveCondition(idx, TFCond_OnFire);
 									}
 								}
 							}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3662,31 +3662,28 @@ Action SDKHookCB_OnTakeDamage(
 						StrEqual(class, "tf_weapon_invis") &&
 						GetEntProp(weapon1, Prop_Send, "m_iItemDefinitionIndex") == 59
 					) {
-						if (
-							GetItemVariant(Wep_DeadRinger) == 0 ||
-							GetItemVariant(Wep_DeadRinger) == 3
-						) {
-							// "Old-Style" Dead Ringer Stats
-							cvar_ref_tf_feign_death_duration.FloatValue = 0.0;
-							cvar_ref_tf_feign_death_speed_duration.FloatValue = 0.0;
-							cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.10;
-							cvar_ref_tf_feign_death_damage_scale.FloatValue = 0.10;
-						}
-						else if (GetItemVariant(Wep_DeadRinger) == 2) {
-							// Pre-Tough Break Dead Ringer Initial Damage Resist Stat
-							cvar_ref_tf_feign_death_duration.RestoreDefault();
-							cvar_ref_tf_feign_death_speed_duration.RestoreDefault();
-							cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.50;
-							cvar_ref_tf_feign_death_damage_scale.RestoreDefault();							
-						} else if (
-							GetItemVariant(Wep_DeadRinger) == -1 ||
-							GetItemVariant(Wep_DeadRinger) == 1
-						) {
-							// Pre-Inferno and Vanilla Dead Ringer Stat reset
-							cvar_ref_tf_feign_death_duration.RestoreDefault();
-							cvar_ref_tf_feign_death_speed_duration.RestoreDefault();
-							cvar_ref_tf_feign_death_activate_damage_scale.RestoreDefault();
-							cvar_ref_tf_feign_death_damage_scale.RestoreDefault();
+						switch (GetItemVariant(Wep_DeadRinger)) {
+							case 0, 3: {
+								// "Old-Style" Dead Ringer Stats
+								cvar_ref_tf_feign_death_duration.FloatValue = 0.0;
+								cvar_ref_tf_feign_death_speed_duration.FloatValue = 0.0;
+								cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.10;
+								cvar_ref_tf_feign_death_damage_scale.FloatValue = 0.10;
+							}
+							case 2: {
+								// Pre-Tough Break Dead Ringer Initial Damage Resist Stat
+								cvar_ref_tf_feign_death_duration.RestoreDefault();
+								cvar_ref_tf_feign_death_speed_duration.RestoreDefault();
+								cvar_ref_tf_feign_death_activate_damage_scale.FloatValue = 0.50;
+								cvar_ref_tf_feign_death_damage_scale.RestoreDefault();
+							}
+							case -1, 1: {
+								// Pre-Inferno and Vanilla Dead Ringer Stat reset
+								cvar_ref_tf_feign_death_duration.RestoreDefault();
+								cvar_ref_tf_feign_death_speed_duration.RestoreDefault();
+								cvar_ref_tf_feign_death_activate_damage_scale.RestoreDefault();
+								cvar_ref_tf_feign_death_damage_scale.RestoreDefault();
+							}
 						}
 					}
 				}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1429,9 +1429,8 @@ public void OnGameFrame() {
 					}
 
 					{
-						// pre-gun mettle deadringer feign buff canceling
+						// "old-style" deadringer feign buff canceling
 						if (
-							GetItemVariant(Wep_DeadRinger) == 0 &&
 							players[idx].spy_is_feigning &&
 							players[idx].spy_under_feign_buffs
 						) {
@@ -4897,7 +4896,8 @@ bool TraceFilter_CustomShortCircuit(int entity, int contentsmask, any data) {
 
 int GetFeignBuffsEnd(int client)
 {
-	return players[client].feign_ready_tick + RoundFloat(66 * 6.5) - RoundFloat(players[client].damage_taken_during_feign * 1.1);
+	int reduction_by_dmg_taken = GetItemVariant(Wep_DeadRinger) == 0 ? RoundFloat(players[client].damage_taken_during_feign * 1.1) : 0;
+	return players[client].feign_ready_tick + RoundFloat(66 * 6.5) - reduction_by_dmg_taken;
 }
 
 bool PlayerIsInvulnerable(int client) {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1888,10 +1888,8 @@ public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &pro
 			TF2_GetPlayerClass(client) == TFClass_Spy
 		) {
 			// prevent speed boost being applied on feign death
-			// handle feign buffs ourselves
 			if (
-				(condition == TFCond_SpeedBuffAlly ||
-				condition == TFCond_DeadRingered) &&
+				condition == TFCond_SpeedBuffAlly &&
 				players[client].feign_ready_tick == GetGameTickCount()
 			) {
 				return Plugin_Handled;


### PR DESCRIPTION
### Summary of changes
remove clientside sound when using "old-style" dead ringer (variants 0 and 3), also removes the "uber" visual effect when under feign buffs
note that the sound may still play if feigning while bleeding or burning, shouldn't play in the majority of cases

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway and itemtest, spy can still tank 5 backstabs and 8 stickies

### Other Info
minor code cleanup near top of the file, something to expand upon later
a single-iteration for loop in OnTakeDamage for the ability to break (probably unnecessary, it's just to be safe)
code sourced from notnheavy's plugin, improved by me