### PR TITLE
(Reverts) Add Amputator and Concheror reverts

### DIFF
--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -10,6 +10,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 0
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 0
@@ -25,6 +26,8 @@ sm_reverts__item_buffalosteak 0
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 0
 sm_reverts__item_carbine 0
+sm_reverts__item_concheror 0
+sm_reverts__item_cowmangler 0
 sm_reverts__item_cozycamper 0
 sm_reverts__item_critcola 0
 sm_reverts__item_crocostyle 0

--- a/cfg/reverts_disable_all.cfg
+++ b/cfg/reverts_disable_all.cfg
@@ -4,11 +4,13 @@
 sm_reverts__old_falldmg_sfx 0
 sm_reverts__enable_dropped_weapon 0
 sm_reverts__pre_toughbreak_switch 0
+sm_reverts__show_moonshot 0
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 0
+sm_reverts__item_amputator 0
 sm_reverts__item_atomizer 0
 sm_reverts__item_axtinguish 0
 sm_reverts__item_backburner 0
@@ -24,6 +26,7 @@ sm_reverts__item_buffalosteak 0
 sm_reverts__item_targe 0
 sm_reverts__item_claidheamh 0
 sm_reverts__item_carbine 0
+sm_reverts__item_concheror 0
 sm_reverts__item_cowmangler 0
 sm_reverts__item_cozycamper 0
 sm_reverts__item_critcola 0

--- a/cfg/reverts_enable_all.cfg
+++ b/cfg/reverts_enable_all.cfg
@@ -10,6 +10,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
@@ -25,6 +26,7 @@ sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 1
+sm_reverts__item_concheror 1
 sm_reverts__item_cowmangler 1
 sm_reverts__item_cozycamper 1
 sm_reverts__item_critcola 1

--- a/cfg/reverts_high.cfg
+++ b/cfg/reverts_high.cfg
@@ -7,6 +7,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
@@ -22,10 +23,11 @@ sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 1
+sm_reverts__item_concheror 1
 sm_reverts__item_cozycamper 1
+sm_reverts__item_cowmangler 1
 sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 1
-sm_reverts__item_cowmangler 1
 sm_reverts__item_dalokohsbar 1
 sm_reverts__item_darwin 1
 sm_reverts__item_ringer 1

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -9,6 +9,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 2
 sm_reverts__item_axtinguish 0
 sm_reverts__item_backburner 0
@@ -24,6 +25,7 @@ sm_reverts__item_buffalosteak 0
 sm_reverts__item_targe 0
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 0
+sm_reverts__item_concheror 0
 sm_reverts__item_cowmangler 0
 sm_reverts__item_cozycamper 0
 sm_reverts__item_critcola 3

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -9,6 +9,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 2
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
@@ -24,6 +25,7 @@ sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 0
+sm_reverts__item_concheror 0
 sm_reverts__item_cowmangler 0
 sm_reverts__item_cozycamper 1
 sm_reverts__item_critcola 2

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -6,6 +6,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 3
@@ -21,6 +22,7 @@ sm_reverts__item_buffalosteak 2
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 1
+sm_reverts__item_concheror 0
 sm_reverts__item_cowmangler 1
 sm_reverts__item_cozycamper 1
 sm_reverts__item_critcola 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -16,6 +16,7 @@ sm_reverts__item_airstrike 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 2
 sm_reverts__item_backburner 0
@@ -33,6 +34,7 @@ sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 2
+sm_reverts__item_concheror 1
 sm_reverts__item_cowmangler 0
 // pre-GM cow mangler had 4 shots, this is the closest
 sm_reverts__item_cozycamper 0

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -42,7 +42,7 @@
 			"CTFPlayer::RegenThink" // offset aAddHealthRegen ; "add_health_regen"
 			{
 				"library" "server"
-				"windows" "\x55\x8B\xEC\x83\xEC\x7C\x56\x8B\xF1"
+				"windows" "\x55\x8B\xEC\x83\xEC\x7C\x56\x8B\xF1\x8B\x06"
 				"linux"   "@_ZN9CTFPlayer10RegenThinkEv"
 			}
 		}

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -38,6 +38,13 @@
 				"windows" "\x55\x8B\xEC\x6A\x07"
 				"linux"   "@_ZN9CTFPlayer13AddToSpyKnifeEfb"
 			}
+
+			"CTFPlayer::RegenThink" // offset aAddHealthRegen ; "add_health_regen"
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\x83\xEC\x7C\x56\x8B\xF1"
+				"linux"   "@_ZN9CTFPlayer10RegenThinkEv"
+			}
 		}
 
 		"Offsets"
@@ -169,6 +176,14 @@
 						"type" "bool"
 					}
 				}
+			}
+
+			"CTFPlayer::RegenThink"
+			{
+				"signature" "CTFPlayer::RegenThink"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "void"
 			}
 		}
 	}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -192,6 +192,7 @@ enum struct Player {
 	int drain_victim;
 	float drain_time;
 	bool spy_under_feign_buffs;
+	bool regen_think_override;
 }
 
 enum struct Entity {
@@ -279,6 +280,7 @@ Handle hudsync;
 // Menu menu_pick;
 int rocket_create_entity;
 int rocket_create_frame;
+int prev_mvm_state;
 
 //cookies
 Cookie g_hClientMessageCookie;
@@ -307,6 +309,7 @@ enum
 	//Specific weapons
 	Wep_Airstrike,
 	Wep_Ambassador,
+	Wep_Amputator,
 	Wep_Atomizer,
 	Wep_Axtinguisher,
 	Wep_BabyFace,
@@ -320,6 +323,7 @@ enum
 	Wep_BuffaloSteak,
 	Wep_Bushwacka,
 	Wep_CharginTarge,
+	Wep_Concheror,
 	Wep_CowMangler,
 #if defined MEMORY_PATCHES
 	Wep_CozyCamper,
@@ -444,6 +448,7 @@ public void OnPluginStart() {
 #endif
 	ItemDefine("swords", "Swords_PreTB", CLASSFLAG_DEMOMAN, Feat_Sword);
 	ItemDefine("ambassador", "Ambassador_PreJI", CLASSFLAG_SPY, Wep_Ambassador);
+	ItemDefine("amputator", "Amputator_PreTB", CLASSFLAG_MEDIC, Wep_Amputator);
 	ItemDefine("atomizer", "Atomizer_PreJI", CLASSFLAG_SCOUT, Wep_Atomizer);
 	ItemVariant(Wep_Atomizer, "Atomizer_PreBM");
 	ItemDefine("axtinguish", "Axtinguisher_PreLW", CLASSFLAG_PYRO, Wep_Axtinguisher);
@@ -469,6 +474,7 @@ public void OnPluginStart() {
 	ItemDefine("claidheamh", "Claidheamh_PreTB", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
 	ItemDefine("carbine", "Carbine_Release", CLASSFLAG_SNIPER, Wep_CleanerCarbine);
 	ItemVariant(Wep_CleanerCarbine, "Carbine_PreTB");
+	ItemDefine("concheror", "Concheror_PreTB", CLASSFLAG_SOLDIER, Wep_Concheror);
 	ItemDefine("cowmangler", "CowMangler_Release", CLASSFLAG_SOLDIER, Wep_CowMangler);
 	ItemVariant(Wep_CowMangler, "CowMangler_Pre2013");
 #if defined MEMORY_PATCHES
@@ -1619,6 +1625,7 @@ public void OnClientConnected(int client) {
 	players[client].medic_medigun_charge = 0.0;
 	players[client].parachute_cond_time = 0.0;
 	players[client].received_help_notice = false;
+	players[client].regen_think_override = false;
 
 	for (int i = 0; i < NUM_ITEMS; i++) {
 		prev_player_weapons[client][i] = false;
@@ -2153,21 +2160,9 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			}
 			sword_reverted = true;
 		}}
-		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
-			switch (GetItemVariant(Wep_CritCola)) {
-				case 0, 1, 2: {
-					TF2Items_SetNumAttributes(itemNew, 2);
-					TF2Items_SetAttribute(itemNew, 0, 814, 0.0); // no mark-for-death on attack
-					// +25% or +10% damage vulnerability while under the effect, depending on variant
-					float vuln = GetItemVariant(Wep_CritCola) == 2 ? 1.25 : 1.10;
-					TF2Items_SetAttribute(itemNew, 1, 798, vuln);
-				}
-				case 3, 4: {
-					TF2Items_SetNumAttributes(itemNew, 1);
-					TF2Items_SetAttribute(itemNew, 0, 814, 0.0); // no mark-for-death on attack
-					// Mini-crit vulnerability handled elsewhere
-				}
-			}
+		case 354: { if (ItemIsEnabled(Wep_Concheror)) {
+			TF2Items_SetNumAttributes(itemNew, 1);
+			TF2Items_SetAttribute(itemNew, 0, 57, 2.0); // +2 health regenerated per second on wearer
 		}}
 		case 441: { if (ItemIsEnabled(Wep_CowMangler)) {
 			switch (GetItemVariant(Wep_CowMangler)) {
@@ -2186,6 +2181,22 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 4, 1, 0.90); // mult_dmg; 10% damage penalty
 				}
 				// no crit boost attribute fix handled elsewhere in SDKHookCB_OnTakeDamage
+			}
+		}}
+		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
+			switch (GetItemVariant(Wep_CritCola)) {
+				case 0, 1, 2: {
+					TF2Items_SetNumAttributes(itemNew, 2);
+					TF2Items_SetAttribute(itemNew, 0, 814, 0.0); // no mark-for-death on attack
+					// +25% or +10% damage vulnerability while under the effect, depending on variant
+					float vuln = GetItemVariant(Wep_CritCola) == 2 ? 1.25 : 1.10;
+					TF2Items_SetAttribute(itemNew, 1, 798, vuln);
+				}
+				case 3, 4: {
+					TF2Items_SetNumAttributes(itemNew, 1);
+					TF2Items_SetAttribute(itemNew, 0, 814, 0.0); // no mark-for-death on attack
+					// Mini-crit vulnerability handled elsewhere
+				}
 			}
 		}}		
 		case 231: { if (ItemIsEnabled(Wep_Darwin)) {
@@ -3004,6 +3015,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 1104:player_weapons[client][Wep_Airstrike] = true;
 						case 61: player_weapons[client][Wep_Ambassador] = true;
 						case 1006: player_weapons[client][Wep_Ambassador] = true;
+						case 304: player_weapons[client][Wep_Amputator] = true;
 						case 450: player_weapons[client][Wep_Atomizer] = true;
 						case 38, 47, 1000: player_weapons[client][Wep_Axtinguisher] = true;
 						case 772: player_weapons[client][Wep_BabyFace] = true;
@@ -3026,8 +3038,9 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 996: player_weapons[client][Wep_LooseCannon] = true;
 						case 751: player_weapons[client][Wep_CleanerCarbine] = true;
 						case 327: player_weapons[client][Wep_Claidheamh] = true;
-						case 163: player_weapons[client][Wep_CritCola] = true;
+						case 354: player_weapons[client][Wep_Concheror] = true;
 						case 441: player_weapons[client][Wep_CowMangler] = true;
+						case 163: player_weapons[client][Wep_CritCola] = true;
 						case 215: player_weapons[client][Wep_Degreaser] = true;
 						case 460: player_weapons[client][Wep_Enforcer] = true;
 						case 128, 775: player_weapons[client][Wep_Pickaxe] = true;
@@ -5981,18 +5994,68 @@ MRESReturn DHookCallback_CTFAmmoPack_MakeHolidayPack(int pThis) {
 }
 #endif
 
-MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int entity)
+MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 {
+	int weapon;
+
+	// Don't proceed if in MvM
     if (cvar_ref_tf_gamemode_mvm.BoolValue)
 		return MRES_Ignored;
+
+	if (
+		client > 0 &&
+		client <= MaxClients
+	) {
+		// Grab secondary weapon
+		weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Secondary);
+
+		if (
+			ItemIsEnabled(Wep_Concheror) &&
+			weapon > 0 &&
+			GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 354
+		) {
+			// Weapon is a Concheror, so fake MvM game state for full regen
+			prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
+			GameRules_SetProp("m_bPlayingMannVsMachine", 1);
+			players[client].regen_think_override = true;
+			return MRES_Ignored;
+		}
+	
+		// Grab active weapon
+		weapon = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+		
+		if (
+			ItemIsEnabled(Wep_Amputator) &&
+			weapon > 0 &&
+			GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 304
+		) {
+			// Weapon is an Amputator, so fake MvM game state for full regen
+			prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
+			GameRules_SetProp("m_bPlayingMannVsMachine", 1);
+			players[client].regen_think_override = true;
+			return MRES_Ignored;
+		}
+	}
 	
     return MRES_Ignored;
 }
 
-MRESReturn DHookCallback_CTFPlayer_RegenThink_Post(int entity)
+MRESReturn DHookCallback_CTFPlayer_RegenThink_Post(int client)
 {
+	// Don't proceed if in MvM
 	if (cvar_ref_tf_gamemode_mvm.BoolValue)
 		return MRES_Ignored;
+
+	if (
+		client > 0 &&
+		client <= MaxClients
+	) {
+		if (players[client].regen_think_override) {
+			// Restore previous gamerule state
+			GameRules_SetProp("m_bPlayingMannVsMachine", prev_mvm_state);
+			players[client].regen_think_override = false;
+		}
+	}
 
     return MRES_Ignored;
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -270,6 +270,7 @@ DynamicDetour dhook_CTFPlayer_CanDisguise;
 DynamicDetour dhook_CTFPlayer_CalculateMaxSpeed;
 DynamicDetour dhook_CTFAmmoPack_PackTouch;
 DynamicDetour dhook_CTFPlayer_AddToSpyKnife;
+DynamicDetour dhook_CTFPlayer_RegenThink;
 
 Player players[MAXPLAYERS+1];
 Entity entities[2048];
@@ -669,6 +670,7 @@ public void OnPluginStart() {
 		dhook_CTFPlayer_CalculateMaxSpeed = DynamicDetour.FromConf(conf, "CTFPlayer::TeamFortress_CalculateMaxSpeed");
 		dhook_CTFPlayer_AddToSpyKnife = DynamicDetour.FromConf(conf, "CTFPlayer::AddToSpyKnife");
 		dhook_CTFAmmoPack_PackTouch =  DynamicDetour.FromConf(conf, "CTFAmmoPack::PackTouch");
+		dhook_CTFPlayer_RegenThink = DynamicDetour.FromConf(conf, "CTFPlayer::RegenThink");
 
 		delete conf;
 	}
@@ -786,11 +788,14 @@ public void OnPluginStart() {
 	if (dhook_CTFPlayer_AddToSpyKnife == null) SetFailState("Failed to create dhook_CTFPlayer_AddToSpyKnife");
 	if (dhook_CAmmoPack_MyTouch == null) SetFailState("Failed to create dhook_CAmmoPack_MyTouch");
 	if (dhook_CTFAmmoPack_PackTouch == null) SetFailState("Failed to create dhook_CTFAmmoPack_PackTouch");
+	if (dhook_CTFPlayer_RegenThink == null) SetFailState("Failed to create dhook_CTFPlayer_RegenThink");
 
 	dhook_CTFPlayer_CanDisguise.Enable(Hook_Post, DHookCallback_CTFPlayer_CanDisguise);
 	dhook_CTFPlayer_CalculateMaxSpeed.Enable(Hook_Post, DHookCallback_CTFPlayer_CalculateMaxSpeed);
 	dhook_CTFPlayer_AddToSpyKnife.Enable(Hook_Pre, DHookCallback_CTFPlayer_AddToSpyKnife);
 	dhook_CTFAmmoPack_PackTouch.Enable(Hook_Pre, DHookCallback_CTFAmmoPack_PackTouch);
+	dhook_CTFPlayer_RegenThink.Enable(Hook_Pre, DHookCallback_CTFPlayer_RegenThink_Pre);
+	dhook_CTFPlayer_RegenThink.Enable(Hook_Post, DHookCallback_CTFPlayer_RegenThink_Post);
 
 	for (idx = 1; idx <= MaxClients; idx++) {
 		if (IsClientConnected(idx)) OnClientConnected(idx);
@@ -5975,6 +5980,22 @@ MRESReturn DHookCallback_CTFAmmoPack_MakeHolidayPack(int pThis) {
 	return MRES_Ignored;
 }
 #endif
+
+MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int entity)
+{
+    if (cvar_ref_tf_gamemode_mvm.BoolValue)
+		return MRES_Ignored;
+	
+    return MRES_Ignored;
+}
+
+MRESReturn DHookCallback_CTFPlayer_RegenThink_Post(int entity)
+{
+	if (cvar_ref_tf_gamemode_mvm.BoolValue)
+		return MRES_Ignored;
+
+    return MRES_Ignored;
+}
 
 float CalcViewsOffset(float angle1[3], float angle2[3]) {
 	float v1;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -6011,14 +6011,15 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 
 		if (
 			ItemIsEnabled(Wep_Concheror) &&
-			weapon > 0 &&
-			GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 354
+			weapon > 0
 		) {
-			// Weapon is a Concheror, so fake MvM game state for full regen
-			prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
-			GameRules_SetProp("m_bPlayingMannVsMachine", 1);
-			players[client].regen_think_override = true;
-			return MRES_Ignored;
+			if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 354) {
+				// Weapon is a Concheror, so fake MvM game state for full regen
+				prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
+				GameRules_SetProp("m_bPlayingMannVsMachine", 1);
+				players[client].regen_think_override = true;
+				return MRES_Ignored;
+			}
 		}
 	
 		// Grab active weapon
@@ -6026,14 +6027,15 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 		
 		if (
 			ItemIsEnabled(Wep_Amputator) &&
-			weapon > 0 &&
-			GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 304
+			weapon > 0
 		) {
-			// Weapon is an Amputator, so fake MvM game state for full regen
-			prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
-			GameRules_SetProp("m_bPlayingMannVsMachine", 1);
-			players[client].regen_think_override = true;
-			return MRES_Ignored;
+			if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 304) {
+				// Weapon is an Amputator, so fake MvM game state for full regen
+				prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
+				GameRules_SetProp("m_bPlayingMannVsMachine", 1);
+				players[client].regen_think_override = true;
+				return MRES_Ignored;
+			}
 		}
 	}
 	

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -192,7 +192,6 @@ enum struct Player {
 	int drain_victim;
 	float drain_time;
 	bool spy_under_feign_buffs;
-	bool regen_think_override;
 }
 
 enum struct Entity {
@@ -281,6 +280,7 @@ Handle hudsync;
 int rocket_create_entity;
 int rocket_create_frame;
 int prev_mvm_state;
+bool regen_think_override = false;
 
 //cookies
 Cookie g_hClientMessageCookie;
@@ -1625,7 +1625,6 @@ public void OnClientConnected(int client) {
 	players[client].medic_medigun_charge = 0.0;
 	players[client].parachute_cond_time = 0.0;
 	players[client].received_help_notice = false;
-	players[client].regen_think_override = false;
 
 	for (int i = 0; i < NUM_ITEMS; i++) {
 		prev_player_weapons[client][i] = false;
@@ -6017,7 +6016,7 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 				// Weapon is a Concheror, so fake MvM game state for full regen
 				prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
 				GameRules_SetProp("m_bPlayingMannVsMachine", 1);
-				players[client].regen_think_override = true;
+				regen_think_override = true;
 				return MRES_Ignored;
 			}
 		}
@@ -6033,7 +6032,7 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 				// Weapon is an Amputator, so fake MvM game state for full regen
 				prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
 				GameRules_SetProp("m_bPlayingMannVsMachine", 1);
-				players[client].regen_think_override = true;
+				regen_think_override = true;
 				return MRES_Ignored;
 			}
 		}
@@ -6052,10 +6051,10 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Post(int client)
 		client > 0 &&
 		client <= MaxClients
 	) {
-		if (players[client].regen_think_override) {
+		if (regen_think_override) {
 			// Restore previous gamerule state
 			GameRules_SetProp("m_bPlayingMannVsMachine", prev_mvm_state);
-			players[client].regen_think_override = false;
+			regen_think_override = false;
 		}
 	}
 

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -474,7 +474,7 @@
 	}
 	"Amputator_PreTB"
 	{
-		"en"	"Reverted health regen to pre-toughbreak, always regenerates +3 HP/s flat when active regardless if recently took damage"
+		"en"	"Reverted to pre-toughbreak, regenerates +3 HP/s flat when active regardless if user recently took damage"
 	}
 	"Atomizer_PreJI"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -142,6 +142,10 @@
 	{
 		"en"	"Ambassador"
 	}
+	"amputator"
+	{
+		"en"	"Amputator"
+	}
 	"atomizer"
 	{
 		"en"	"Atomizer"
@@ -201,6 +205,10 @@
 	"carbine"
 	{
 		"en"	"Cleaner's Carbine"
+	}
+	"concheror"
+	{
+		"en"	"Concheror"
 	}
 	"cowmangler"
 	{
@@ -464,6 +472,10 @@
 	{
 		"en"	"Reverted to pre-inferno, deals full headshot damage (102) at all ranges"
 	}
+	"Amputator_PreTB"
+	{
+		"en"	"Reverted healing to pre-toughbreak, always heals +3 HP/s flat when active regardless if recently took damage"
+	}
 	"Atomizer_PreJI"
 	{
 		"en"	"Reverted to pre-inferno, can always triple jump, taking 10 damage each time"
@@ -563,6 +575,10 @@
 	"Carbine_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, minicrits for 8 seconds on kill, 35%% slower fire rate (from 25%%)"
+	}
+	"Concheror_PreTB"
+	{
+		"en"	"Reverted to pre-toughbreak, heals +2 HP/s flat regardless if recently took damage"
 	}
 	"CowMangler_Release"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -474,7 +474,7 @@
 	}
 	"Amputator_PreTB"
 	{
-		"en"	"Reverted healing to pre-toughbreak, always heals +3 HP/s flat when active regardless if recently took damage"
+		"en"	"Reverted health regen to pre-toughbreak, always regenerates +3 HP/s flat when active regardless if recently took damage"
 	}
 	"Atomizer_PreJI"
 	{
@@ -578,7 +578,7 @@
 	}
 	"Concheror_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, heals +2 HP/s flat regardless if recently took damage"
+		"en"	"Reverted to pre-toughbreak, regenerates +2 HP/s flat regardless if recently took damage"
 	}
 	"CowMangler_Release"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -578,7 +578,7 @@
 	}
 	"Concheror_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, regenerates +2 HP/s flat regardless if recently took damage"
+		"en"	"Reverted to pre-toughbreak, regenerates +2 HP/s flat regardless if user recently took damage"
 	}
 	"CowMangler_Release"
 	{


### PR DESCRIPTION
### Summary of changes
Amputator - Reverted health regen to pre-toughbreak, always regenerates +3 HP/s flat when active regardless if recently took damage
Concheror - Reverted to pre-toughbreak, regenerates +2 HP/s flat regardless if recently took damage

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway, cozy camper is unaffected

### Other Info
full regen is achieved by faking the MvM gamerule for the scope in which the regeneration code runs per client
gamedata by notnheavy and verdiusarcana
