### PR TITLE
(Reverts) Make Rescue Ranger revert available patchless

### DIFF
--- a/gamedata/memorypatch_reverts.txt
+++ b/gamedata/memorypatch_reverts.txt
@@ -28,12 +28,6 @@
 				"windows" "\x55\x8B\xEC\x83\xEC\x08\x53\x56\x8B\xF1\x57\x80\xBE\x2A\x2A\x2A\x2A\x00\x74"
  				"linux"   "@_ZN16CObjectSentrygun11OnWrenchHitEP9CTFPlayerP9CTFWrench6Vector"
 			}
-			"CTFProjectile_Arrow::BuildingHealingArrow"
-			{
-				"library" "server"
-				"windows" "\x55\x8B\xEC\x83\xEC\x24\x53\x56\x57\x8B\x7D\x2A\x8B\xD9\x57"
-				"linux"   "@_ZN19CTFProjectile_Arrow20BuildingHealingArrowEP11CBaseEntity"
-			}
 			"CTFProjectile_BallOfFire::Burn"
 			{
 				"library" "server"
@@ -69,12 +63,6 @@
 				"library" "server"
 				"windows" "\x55\x8B\xEC\x83\xEC\x08\x53\x56\x8B\xF1\xB3\x01"
 				"linux"   "@_ZN9CTFPlayer18ApplyPunchImpulseXEf"
-			}
-			"CBaseMultiplayerPlayer::AwardAchievement"
-			{
-				"library" "server"
-				"linux"	  "@_ZN22CBaseMultiplayerPlayer16AwardAchievementEii"
-				"windows" "\x55\x8B\xEC\x83\xEC\x20\x56\x8B\xF1\x8D\x4D\x2A\xE8\x2A\x2A\x2A\x2A\x56\x8D\x4D\x2A\xC7\x45\x2A\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x8D\x45\x2A\x68\x2A\x2A\x2A\x2A\x50\xE8\x2A\x2A\x2A\x2A\xFF\x75" // Loooong signature.
 			}
 			"CTFPlayer::TeamFortress_CalculateMaxSpeed"
 			{
@@ -440,40 +428,6 @@
 			}
 		"Functions"
 		{
-			"CTFProjectile_Arrow::BuildingHealingArrow"
-			{
-				"signature" "CTFProjectile_Arrow::BuildingHealingArrow"
-				"callconv"  "thiscall"
-				"this"      "entity"
-				"return"    "void"
-				"arguments"
-				{
-					"pOther"
-					{
-						"type" "cbaseentity"
-					}
-				}
-			}
-
-			"CBaseMultiplayerPlayer::AwardAchievement"
-			{
-				"signature" "CBaseMultiplayerPlayer::AwardAchievement"
-				"callconv"  "thiscall"
-				"this"      "entity"
-				"return"    "void"
-				"arguments"
-				{
-					"iAchievement"
-					{
-						"type" "int"
-					}
-					"iCount"
-					{
-						"type" "int"
-					}
-				}
-			}
-
 			"CTFAmmoPack::MakeHolidayPack"
 			{
 				"signature" "CTFAmmoPack::MakeHolidayPack"

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -39,6 +39,20 @@
 				"linux"   "@_ZN9CTFPlayer13AddToSpyKnifeEfb"
 			}
 
+			"CTFProjectile_Arrow::BuildingHealingArrow"
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\x83\xEC\x24\x53\x56\x57\x8B\x7D\x2A\x8B\xD9\x57"
+				"linux"   "@_ZN19CTFProjectile_Arrow20BuildingHealingArrowEP11CBaseEntity"
+			}
+
+			"CBaseMultiplayerPlayer::AwardAchievement"
+			{
+				"library" "server"
+				"linux"	  "@_ZN22CBaseMultiplayerPlayer16AwardAchievementEii"
+				"windows" "\x55\x8B\xEC\x83\xEC\x20\x56\x8B\xF1\x8D\x4D\x2A\xE8\x2A\x2A\x2A\x2A\x56\x8D\x4D\x2A\xC7\x45\x2A\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x8D\x45\x2A\x68\x2A\x2A\x2A\x2A\x50\xE8\x2A\x2A\x2A\x2A\xFF\x75" // Loooong signature.
+			}
+
 			"CTFPlayer::RegenThink" // offset aAddHealthRegen ; "add_health_regen"
 			{
 				"library" "server"
@@ -174,6 +188,40 @@
 					"force"
 					{
 						"type" "bool"
+					}
+				}
+			}
+
+			"CTFProjectile_Arrow::BuildingHealingArrow"
+			{
+				"signature" "CTFProjectile_Arrow::BuildingHealingArrow"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "void"
+				"arguments"
+				{
+					"pOther"
+					{
+						"type" "cbaseentity"
+					}
+				}
+			}
+
+			"CBaseMultiplayerPlayer::AwardAchievement"
+			{
+				"signature" "CBaseMultiplayerPlayer::AwardAchievement"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "void"
+				"arguments"
+				{
+					"iAchievement"
+					{
+						"type" "int"
+					}
+					"iCount"
+					{
+						"type" "int"
 					}
 				}
 			}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2155,14 +2155,13 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		}}
 		case 327: { if (ItemIsEnabled(Wep_Claidheamh)) {
 			bool swords = ItemIsEnabled(Feat_Sword);
-			TF2Items_SetNumAttributes(itemNew, swords ? 5 : 3);
+			TF2Items_SetNumAttributes(itemNew, swords ? 4 : 3);
 			TF2Items_SetAttribute(itemNew, 0, 412, 1.00); // dmg taken
 			TF2Items_SetAttribute(itemNew, 1, 128, 0.0); // provide on active
 			TF2Items_SetAttribute(itemNew, 2, 125, -15.0); // max health additive penalty
 			// sword holster code handled here
 			if (swords) {
 				TF2Items_SetAttribute(itemNew, 3, 781, 0.0); // is a sword
-				TF2Items_SetAttribute(itemNew, 4, 264, 1.0); // melee range multiplier; 1.0 somehow corresponds to 72 hammer units from testing
 			}
 			sword_reverted = true;
 		}}
@@ -2473,7 +2472,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		}}
 		case 404: { if (ItemIsEnabled(Wep_Persian)) {
 			bool swords = ItemIsEnabled(Feat_Sword);
-			TF2Items_SetNumAttributes(itemNew, swords ? 8 : 6);
+			TF2Items_SetNumAttributes(itemNew, swords ? 7 : 6);
 			TF2Items_SetAttribute(itemNew, 0, 77, 1.00); // -0% max primary ammo on wearer
 			TF2Items_SetAttribute(itemNew, 1, 79, 1.00); // -0% max secondary ammo on wearer
 			TF2Items_SetAttribute(itemNew, 2, 778, 0.00); // remove "Melee hits refill 20% of your charge meter" attribute
@@ -2482,7 +2481,6 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 5, 258, 1.0); // Ammo collected from ammo boxes becomes health (doesn't work, using two DHooks instead)
 			if (swords) {
 				TF2Items_SetAttribute(itemNew, 6, 781, 0.0); // is a sword
-				TF2Items_SetAttribute(itemNew, 7, 264, 1.0); // melee range multiplier; 1.0 somehow corresponds to 72 hammer units from testing
 			}
 			sword_reverted = true;
 		}}
@@ -2730,12 +2728,12 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 	if (
 		ItemIsEnabled(Feat_Sword) &&
 		!sword_reverted && //must be set to true on every weapon that implements Feat_Sword check! 
-		( StrEqual(class, "tf_weapon_sword") ||
+		(StrEqual(class, "tf_weapon_sword") ||
 		(!ItemIsEnabled(Wep_Zatoichi) && (index == 357)) )
 	) {
 		TF2Items_SetNumAttributes(itemNew, 2);
 		TF2Items_SetAttribute(itemNew, 0, 781, 0.0); // is a sword
-		TF2Items_SetAttribute(itemNew, 1, 264, 1.0); // melee range multiplier; 1.0 somehow corresponds to 72 hammer units from testing
+		TF2Items_SetAttribute(itemNew, 1, 264, (index == 357) ? 1.50 : 1.0); // melee range multiplier
 	}
 
 	if (TF2Items_GetNumAttributes(itemNew)) {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -5317,7 +5317,6 @@ int HealBuilding(int buildingIndex, int engineerIndex) {
 
 	// Hook attribute class to get repair amount
 	float RepairAmountFloat = TF2Attrib_HookValueFloat(0.0, "arrow_heals_buildings", engineerIndex);
-	RepairAmountFloat = fmin(RepairAmountFloat,float(GetEntProp(buildingIndex, Prop_Data, "m_iMaxHealth") - GetEntProp(buildingIndex, Prop_Data, "m_iHealth")));
 
 	// Reduce healing amount if wrangled sentry.
 	// If wrangler revert is enabled, then the sentry is faked as unshielded, thus allowing full heals
@@ -5326,6 +5325,8 @@ int HealBuilding(int buildingIndex, int engineerIndex) {
 			RepairAmountFloat *= SHIELD_NORMAL_VALUE;
 		}
 	}
+
+	RepairAmountFloat = fmin(RepairAmountFloat,float(GetEntProp(buildingIndex, Prop_Data, "m_iMaxHealth") - GetEntProp(buildingIndex, Prop_Data, "m_iHealth")));
 
 	int currentHealth = GetEntProp(buildingIndex, Prop_Data, "m_iHealth");
 	int RepairAmount = RoundToNearest(RepairAmountFloat);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -570,6 +570,7 @@ public void OnPluginStart() {
 	ItemDefine("quickiebomb", "Quickiebomb_PreMYM", CLASSFLAG_DEMOMAN, Wep_Quickiebomb);
 	ItemDefine("razorback","Razorback_PreJI", CLASSFLAG_SNIPER, Wep_Razorback);
 	ItemDefine("rescueranger", "RescueRanger_PreGM", CLASSFLAG_ENGINEER, Wep_RescueRanger);
+	ItemVariant(Wep_RescueRanger, "RescueRanger_PreJI");
 	ItemDefine("reserve", "Reserve_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_PYRO, Wep_ReserveShooter);
 	ItemVariant(Wep_ReserveShooter, "Reserve_PreJI");
 	ItemDefine("bison", "Bison_PreMYM", CLASSFLAG_SOLDIER, Wep_Bison);
@@ -2510,7 +2511,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 2, 669, 4.00); // Stickybombs fizzle 4 seconds after landing
 			TF2Items_SetAttribute(itemNew, 3, 670, 0.50); // Max charge time decreased by 50%
 		}}
-		case 997: { if (ItemIsEnabled(Wep_RescueRanger)) {
+		case 997: { if (GetItemVariant(Wep_RescueRanger) == 0) {
 			TF2Items_SetNumAttributes(itemNew, 2);
 			TF2Items_SetAttribute(itemNew, 0, 469, 130.0); // ranged pickup metal cost
 			TF2Items_SetAttribute(itemNew, 1, 474, 75.0); // repair bolt healing amount

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -146,6 +146,10 @@
 	{
 		"fi"	"Suurlähettiläs"
 	}
+	"amputator"
+	{
+		"fi"	"Amputoija"
+	}
 	"atomizer"
 	{
 		"fi"	"Atomisoija"
@@ -205,6 +209,10 @@
 	"carbine"
 	{
 		"fi"	"Sarjatulisiivoaja"
+	}
+	"concheror"
+	{
+		"fi"	"Näkinkeisari"
 	}
 	"cowmangler"
 	{
@@ -468,6 +476,10 @@
 	{
 		"fi"	"Ennen Jungle Infernoa: täysi pääosumavahinko (102) kaikilla etäisyyksillä"
 	}
+	"Amputator_PreTB"
+	{
+		"fi"	"Ennen Tough Breakiä: palauttaa tasan +3 HP/s käytössä riippumatta siitä, ottiko käyttäjä viime aikana vahinkoa"
+	}
 	"Atomizer_PreJI"
 	{
 		"fi"	"Ennen Jungle Infernoa: kolmoishyppy on passiivinen, kolmoishyppy aiheuttaa 10 vahinkoa"
@@ -568,6 +580,10 @@
 	{
 		"fi"	"Ennen Tough Breakiä: tapot antavat minikriittisiä 8 sekunniksi, 35%% hitaampi tulitusnopeus (25%%:sta)"
 	}
+	"Concheror_PreTB"
+	{
+		"fi"	"Ennen Tough Breakiä: palauttaa tasan +2 HP/s riippumatta siitä, ottiko käyttäjä viime aikana vahinkoa"
+	}
 	"CowMangler_Release"
 	{
 		"fi"	"Julkaisuversio: 5 ammusta, ei voi kriittisyystehostaa"
@@ -618,7 +634,7 @@
 	}
 	"Ringer_PreGM"
 	{
-		"fi"	"Ennen Gun Mettleä: voi kerätä ammuksia, 90%% vahingonsieto jopa 6,5 sekunniksi (vahinko vähentää aikaa), ei nopeuslisää"
+		"fi"	"Ennen Gun Mettleä: voi kerätä ammuksia, 90%% vahingonsieto jopa 6,5 sekunniksi (vahinko vähentää aikaa), ei nopeuslisää tai jälkipolttoimmuniteettiä"
 	}
 	"Ringer_PreJI"
 	{
@@ -630,11 +646,11 @@
 	}
 	"Ringer_PostRelease"
 	{
-		"fi"	"Julkaisun jälkeinen versio: 90%% vahingonsieto 6,5 sekunniksi, ei nopeuslisää, aikainen verhoistapoistuminen tyhjentää verhoutumismittarin"
+		"fi"	"Julkaisun jälkeinen versio: 90%% vahingonsieto 6,5 sekunniksi, ei nopeuslisää tai jälkipolttoimmuniteettiä, aikainen verhoistapoistuminen tyhjentää verhoutumismittarin"
 	}
 	"Degreaser_PreTB"
 	{
-		"fi"	"Ennen Tough Breakiä: 65%% nopeampi aseen vaihto, -10%% vahinkoa ja -25%% jälkipolttovahinkoa"
+		"fi"	"Ennen Tough Breakiä: 65%% nopeampi aseen vaihto, -10%% vahinkoa ja -25%% jälkipolttovahinkoa, ei lisättyä ilmapuhalluksen kustannusta"
 	}
 	"Disciplinary_PreMYM"
 	{
@@ -823,6 +839,10 @@
 	"RescueRanger_PreGM"
 	{
 		"fi"	"Ennen Gun Mettleä: parantaa tasan +75, ei kuluta metallia, kaukonostot kuluttavat 130 metallia"
+	}
+	"RescueRanger_PreJI"
+	{
+		"fi"	"Ennen Jungle Infernoa: rakennusten parantaminen ei kuluta metallia"
 	}
 	"Reserve_PreTB"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -836,6 +836,10 @@
 	{
 		"en"	"Reverted to pre-gunmettle, heals +75 flat, no metal cost, 130 cost long ranged pickups"
 	}
+	"RescueRanger_PreJI"
+	{
+		"en"	"Reverted to pre-inferno, no metal cost for healing buildings"
+	}
 	"Reserve_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, minicrits all airborne targets for 5 sec after deploying, 15%% faster weapon switch"


### PR DESCRIPTION
### Summary of changes
title, alongside pre-inferno variant
reverted wrangler gets full heal from any rescue ranger variant (including vanilla)

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway

### Other Info
fix the building heal amount being negative
fix sword range for un-reverted zatoichi with swords revert enabled
update finnish locale