### PR TITLE
(Reverts) Historically accurate bash damage

### DIFF
--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -10,6 +10,7 @@ sm_reverts__item_airstrike 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
+sm_reverts__item_amputator 1
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
@@ -25,6 +26,7 @@ sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 1
+sm_reverts__item_concheror 1
 sm_reverts__item_cowmangler 1
 sm_reverts__item_cozycamper 1
 sm_reverts__item_critcola 1

--- a/cfg/reverts_enable_itemsets.cfg
+++ b/cfg/reverts_enable_itemsets.cfg
@@ -43,10 +43,11 @@ sm_reverts__item_warrior 1
 
 
 // MEDIC - The Medieval Medic
-// Item set revert for Medic not done yet, because reverting the Amputator is technically difficult.
+// Item set revert for Medic not done yet
 // To do: Add +1 hp regeneration on wearer bonus
 // To do: Add pre-2013 Crusador's Crossbow
-// To do: Add pre-2013 Amputator (difficult to do because of newer Medic hp regeneration mechanics)
+// To do: Add pre-2013 Amputator
+sm_reverts__item_amputator 1
 
 
 // SNIPER - The Croc-o-Style Kit

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -62,7 +62,7 @@ sm_reverts__item_pocket 2
 sm_reverts__item_quickfix 1
 sm_reverts__item_quickiebomb 0
 sm_reverts__item_razorback 1
-sm_reverts__item_rescueranger 1
+sm_reverts__item_rescueranger 2
 sm_reverts__item_reserve 1
 sm_reverts__item_bison 1
 sm_reverts__item_rocketjmp 2

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4237,8 +4237,8 @@ Action SDKHookCB_OnTakeDamage(
 				if (
 					damage_custom == TF_DMG_CUSTOM_CHARGE_IMPACT &&
 					((ItemIsEnabled(Wep_CharginTarge) && player_weapons[attacker][Wep_CharginTarge]) ||
-					 (ItemIsEnabled(Wep_SplendidScreen) && player_weapons[attacker][Wep_SplendidScreen]) ||
-					 (ItemIsEnabled(Wep_TideTurner) && player_weapons[attacker][Wep_TideTurner])) &&
+					(ItemIsEnabled(Wep_SplendidScreen) && player_weapons[attacker][Wep_SplendidScreen]) ||
+					(ItemIsEnabled(Wep_TideTurner) && player_weapons[attacker][Wep_TideTurner])) &&
 					StrEqual(class, "tf_wearable_demoshield")
 				) {
 					// crit after shield bash if melee is active weapon
@@ -4255,6 +4255,16 @@ Action SDKHookCB_OnTakeDamage(
 							return Plugin_Handled;
 						}
 					}
+
+					// set bash damage with base of 50 and add 10 damage per head, up to 5 heads
+					// bash damage had no rampup over time
+					damage = 50.0 + 10.0 * intMin(GetEntProp(attacker, Prop_Send, "m_iDecapitations"), 5);
+
+					// increase damage from splendid screen attribute
+					damage *= TF2Attrib_HookValueFloat(1.0, "charge_impact_damage", weapon);
+					
+					returnValue = Plugin_Changed;
+					break;
 				}
 			}
 

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4257,7 +4257,7 @@ Action SDKHookCB_OnTakeDamage(
 					}
 
 					// set bash damage with base of 50 and add 10 damage per head, up to 5 heads
-					// bash damage had no rampup over time
+					// bash damage had no rampup based on charge depleted
 					damage = 50.0 + 10.0 * intMin(GetEntProp(attacker, Prop_Send, "m_iDecapitations"), 5);
 
 					// increase damage from splendid screen attribute

--- a/translations/fi/reverts.phrases.txt
+++ b/translations/fi/reverts.phrases.txt
@@ -950,11 +950,11 @@
 	}
 	"Splendid_PreTB"
 	{
-		"fi"	"Ennen Tough Breakiä: 15%% räjähdyssieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko kaikilta etäisyyksiltä"
+		"fi"	"Ennen Tough Breakiä: 15%% räjähdyssieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, täysi ryntäysvahinko kaikilta etäisyyksiltä"
 	}
 	"Splendid_Release"
 	{
-		"fi"	"Julkaisuversio: 25%% tulensieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, ryntäysvahinko kaikilta etäisyyksiltä"
+		"fi"	"Julkaisuversio: 25%% tulensieto, ei nopeampaa latausaikaa, kriittinen osuma ryntäysosuman jälkeen, ei heikennyspoistoa, täysi ryntäysvahinko kaikilta etäisyyksiltä"
 	}
 	"SpyCicle_PreGM"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -946,11 +946,11 @@
 	}
 	"Splendid_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal, bash dmg at any range"
+		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal, full bash dmg at any range"
 	}
 	"Splendid_Release"
 	{
-		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal, bash dmg at any range"
+		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal, full bash dmg at any range"
 	}
 	"SpyCicle_PreGM"
 	{


### PR DESCRIPTION
### Summary of changes
Bash damage before Tough Break used to be 50 base + 10 per head collected (max of 5), vanilla is 50 base + 5 per head collected (max of 5) (for splendid screen both the base and per head dmg are increased by 70%, allowing up to 170 dmg on bash)
Bash damage before Tough Break was not scaled by charge depleted as well

references:
https://wiki.teamfortress.com/w/index.php?title=Chargin%27_Targe&oldid=2009130
https://wiki.teamfortress.com/w/index.php?title=Splendid_Screen&oldid=2004942
https://wiki.teamfortress.com/w/index.php?title=Tide_Turner&oldid=1932148

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway

### Other Info
sourced from notnheavy's plugin, modified by me to be more readable and using attrib hook
