### PR TITLE
(Reverts) Release Red-Tape Recorder

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -376,6 +376,7 @@ enum
 	Wep_QuickFix,
 	Wep_Quickiebomb,
 	Wep_Razorback,
+	Wep_RedTapeRecorder,
 	Wep_RescueRanger,
 	Wep_ReserveShooter,
 	Wep_Bison, // Righteous Bison
@@ -560,6 +561,7 @@ public void OnPluginStart() {
 #endif
 	ItemDefine("quickiebomb", "Quickiebomb_PreMYM", CLASSFLAG_DEMOMAN, Wep_Quickiebomb);
 	ItemDefine("razorback","Razorback_PreJI", CLASSFLAG_SNIPER, Wep_Razorback);
+	ItemDefine("redtape","RedTapeRecorder_Release", CLASSFLAG_SPY, Wep_RedTapeRecorder);
 	ItemDefine("rescueranger", "RescueRanger_PreGM", CLASSFLAG_ENGINEER, Wep_RescueRanger);
 	ItemVariant(Wep_RescueRanger, "RescueRanger_PreJI");
 	ItemDefine("reserve", "Reserve_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_PYRO, Wep_ReserveShooter);
@@ -2500,6 +2502,10 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetAttribute(itemNew, 2, 669, 4.00); // Stickybombs fizzle 4 seconds after landing
 			TF2Items_SetAttribute(itemNew, 3, 670, 0.50); // Max charge time decreased by 50%
 		}}
+		case 810, 831: { if (ItemIsEnabled(Wep_RedTapeRecorder)) {
+			TF2Items_SetNumAttributes(itemNew, 1);
+			TF2Items_SetAttribute(itemNew, 0, 433, 0.9); // Downgrade speed; sapper_degenerates_buildings; default is 0.5 (3 seconds). release was 1.6 seconds (0.9 according to https://wiki.teamfortress.com/wiki/August_2,_2012_Patch)
+		}}
 		case 997: { if (GetItemVariant(Wep_RescueRanger) == 0) {
 			TF2Items_SetNumAttributes(itemNew, 2);
 			TF2Items_SetAttribute(itemNew, 0, 469, 130.0); // ranged pickup metal cost
@@ -3067,6 +3073,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 404: player_weapons[client][Wep_Persian] = true;
 						case 411: player_weapons[client][Wep_QuickFix] = true;
 						case 1150: player_weapons[client][Wep_Quickiebomb] = true;
+						case 810, 831: player_weapons[client][Wep_RedTapeRecorder] = true;
 						case 997: player_weapons[client][Wep_RescueRanger] = true;
 						case 415: player_weapons[client][Wep_ReserveShooter] = true;
 						case 59: player_weapons[client][Wep_DeadRinger] = true;

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -354,6 +354,10 @@
 	{
 		"en"	"Razorback"
 	}
+	"redtape"
+	{
+		"en"	"Red-Tape Recorder"
+	}
 	"rescueranger"
 	{
 		"en"	"Rescue Ranger"
@@ -831,6 +835,10 @@
 	"Razorback_PreJI"
 	{
 		"en"	"Reverted to pre-inferno, can be overhealed, shield does not regenerate"
+	}
+	"RedTapeRecorder_Release"
+	{
+		"en"	"Reverted to release, faster downgrade speed on upgraded enemy buildings (1.6 s)"
 	}
 	"RescueRanger_PreGM"
 	{


### PR DESCRIPTION
### Summary of changes
This only reverts the **downgrade** speed to that of the release Red-Tape Recorder. Deconstruction speed is not the same as downgrade speed! Does not revert being able to survive more than 1 hit from the Homewrecker (due to lack of historical information), and doesn't clear metal from dispensers when downgraded (not sure how).

This means that a buildings gets downgraded in 1.6 s from Lvl 3 to Lvl 2, and from Lvl 2 to Lvl 1. But when a building reaches Lvl 1, it still has the slow deconstruction speed. See this [video](https://www.youtube.com/watch?v=Blqvt995_2M) to see what I'm talking about.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Tested on itemtest with obj_ buildings and compared with the video demonstration for accuracy.

### Other Info
See the following links for references:
[Video Demonstration](https://www.youtube.com/watch?v=Blqvt995_2M)
[Source for 0.9 attribute value: team fortress 2 content.gcf/tf/scripts/items/items_game.txt](https://wiki.teamfortress.com/wiki/August_2,_2012_Patch)
[Changelog](https://wiki.teamfortress.com/wiki/August_3,_2012_Patch)

When this gets merged I might forget to add this to the Wiki and to the changelog.
