### PR TITLE
Compile patchless and win32 reverts as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Preprocess reverts.sp
         run: ./reverts-git-commit.sh
 
+      - name: Make Windows and Patchless reverts variants
+        run: |
+          cd scripting
+          cp reverts.sp reverts-patchless.sp
+          cp reverts.sp reverts-win32.sp
+          sed -i "1i#define NO_MEMPATCHES" reverts-patchless.sp
+          sed -i "1i#define WIN32" reverts-win32.sp
+
       - name: Build plugins
         run: |
           cd scripting


### PR DESCRIPTION
### Summary of changes
> > Pre-compiled plugins are on the Actions page
> 
> Could you add compiling the win32 and patchless versions to the actions? 

 _Originally posted by @haaksirikko in [#273](https://github.com/rsedxcftvgyhbujnkiqwe/castaway-plugins/issues/273#issuecomment-3210080411)_

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
N/A

### Other Info
N/A
