### PR TITLE
(Reverts) Add full bash damage description to other shields

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -570,7 +570,7 @@
 	}
 	"Targe_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, 40%% blast resistance, afterburn immunity, crit after bash, no debuff removal, bash dmg at 60%% depleted"
+		"en"	"Reverted to pre-toughbreak, 40%% blast resistance, afterburn immunity, crit after bash, no debuff removal, full bash dmg at end of charge"
 	}
 	"Claidheamh_PreTB"
 	{
@@ -1002,7 +1002,7 @@
 	}	
 	"Turner_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, can deal full crits, 25%% blast and fire resist, crit after bash, no debuff removal, bash dmg at 60%% depleted"
+		"en"	"Reverted to pre-toughbreak, can deal full crits, 25%% blast and fire resist, crit after bash, no debuff removal, full bash dmg at end of charge"
 	}
 	"Tomislav_PrePyro"
 	{


### PR DESCRIPTION
### Summary of changes
Also changed phrasing to end of charge, since 60% charge seems not intuitive and confusing. Edited Chargin' Targe and Tide Turner descriptions.

### Testing Attestation
- [ ] - This change has been tested
- [X] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
[Any other information you'd like to provide]
