### PR TITLE
(Reverts) Phlogistinator Variants

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -59,6 +59,14 @@
 				"windows" "\x55\x8B\xEC\x83\xEC\x7C\x56\x8B\xF1\x8B\x06"
 				"linux"   "@_ZN9CTFPlayer10RegenThinkEv"
 			}
+
+			// "CTFPlayerShared::ModifyRage"
+			"CTFPlayerShared::SetRageMeter" // aRageOnHit "rage_on_hit", go to subroutine call after SIMD instruction ~~go to subroutine (2nd line down previously) that is just a one-liner func call~~
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\xF3\x0F\x10\x45\x08\x83\xEC\x08"
+				"linux"	  "@_ZN15CTFPlayerShared12SetRageMeterEf"
+			}			
 		}
 
 		"Offsets"
@@ -91,6 +99,12 @@
 			{
 				"windows" "234"
 				"linux"   "237"
+			}
+
+			"CTFPlayerShared::m_pOuter"
+			{
+				"windows" "396"
+				"linux"	  "396"
 			}
 		}
 
@@ -233,6 +247,22 @@
 				"this"      "entity"
 				"return"    "void"
 			}
+
+			//"CTFPlayerShared::ModifyRage"
+			"CTFPlayerShared::SetRageMeter"
+			{
+				"signature" "CTFPlayerShared::SetRageMeter"
+				"callconv"  "thiscall"
+				"this"      "address"
+				"return"    "void"
+				"arguments"
+				{
+					"fDelta"
+					{
+						"type" "float"
+					}
+				}
+			}			
 		}
 	}
 }

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1904,11 +1904,12 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 			TF2_IsPlayerInCondition(client, TFCond_UberchargedCanteen) &&
 			TF2_IsPlayerInCondition(client, TFCond_MegaHeal)
 		) {
+				PrintToChat(client, "Detected Mmmph taunt", 0);
 			health_cur = GetClientHealth(client);
 			health_max = SDKCall(sdkcall_GetMaxHealth, client);
 			if (health_cur < health_max) {
 				SetEntProp(client, Prop_Send, "m_iHealth", health_max);
-					PrintToChat(client, "Detected Mmmph taunt, setting health to full", 0);
+					PrintToChat(client, "Detected health not full, setting health to full", 0);
 			}
 			if (GetItemVariant(Wep_Phlogistinator) == 0 || GetItemVariant(Wep_Phlogistinator) == 2) {
 				TF2_RemoveCondition(client, TFCond_UberchargedCanteen);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1928,6 +1928,17 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 					TF2_AddCondition(client, TFCond_DefenseBuffMmmph, 3.0, 0);
 						PrintToChat(client, "Detected Pyromania Phlogistinator, adding TFCond_DefenseBuffMmmph", 0);
 				}
+				if (GetItemVariant(Wep_Phlogistinator) == 2) {
+					// not sure how to make release phlog have 90% defense via conditions. i'll get to this later.
+					// changelog says 12 seconds, but the wiki says 13 seconds. i think i'll set it to 13 instead because of the taunt duration.
+					TF2_AddCondition(client, TFCond_CritMmmph, 13.0, 0);
+						PrintToChat(client, "Detected Release Phlogistinator, adding TFCond_CritMmmph for 13 sec", 0);
+				}
+			}
+			if (GetItemVariant(Wep_Phlogistinator) == 1) {
+				TF2_AddCondition(client, TFCond_UberchargedCanteen, 4.0, 0); 
+				// a bit of Uber left over when taunt ends for historical accuracy. i am not sure how exactly long it was, this is just a guess.
+					PrintToChat(client, "Detected Tough Break Phlogistinator, adding TFCond_UberchargedCanteen for 4 sec", 0);
 			}
 		}
 	}	
@@ -6287,6 +6298,7 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Post(int client)
 
 MRESReturn ModifyRageMeter(Address thisPointer, DHookParam parameters)
 {
+	// Imported from NotnHeavy's plugin
     int client = GetEntityFromAddress(Dereference(thisPointer + CTFPlayerShared_m_pOuter));
 	int weapon;
 		// Grab primary weapon

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1936,9 +1936,9 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 				}
 			}
 			if (GetItemVariant(Wep_Phlogistinator) == 1) {
-				TF2_AddCondition(client, TFCond_UberchargedCanteen, 4.0, 0); 
+				TF2_AddCondition(client, TFCond_UberchargedCanteen, 3.5, 0); 
 				// a bit of Uber left over when taunt ends for historical accuracy. i am not sure how exactly long it was, this is just a guess.
-					PrintToChat(client, "Detected Tough Break Phlogistinator, adding TFCond_UberchargedCanteen for 4 sec", 0);
+					PrintToChat(client, "Detected Tough Break Phlogistinator, adding TFCond_UberchargedCanteen for 3.5 sec", 0);
 			}
 		}
 	}	
@@ -4819,6 +4819,30 @@ Action SDKHookCB_OnTakeDamageAlive(
 				players[victim].old_health = GetClientHealth(victim);
 				SetEntityHealth(victim, 500);
 					//PrintToChat(victim, "SJ: set health to 500, tanking...", 0);
+			}
+		}
+		{
+			if (
+				((GetItemVariant(Wep_Phlogistinator) == 2 && player_weapons[victim][Wep_Phlogistinator])) &&
+				TF2_GetPlayerClass(victim) == TFClass_Pyro &&
+				TF2_IsPlayerInCondition(victim, TFCond_Taunting) &&
+				TF2_IsPlayerInCondition(victim, TFCond_CritMmmph) &&
+				TF2Attrib_HookValueInt(0, "mod_pierce_resists_absorbs", weapon) == 0 // Don't resist if weapon pierces resists (vanilla Enforcer)
+			) {
+				// Release Phlogistinator 90% damage resistance when taunting (still damaged by crits!)
+				// https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/tf/tf_shareddefs.h#L735
+
+				// apply resistance
+				if (damage_type & DMG_CRIT != 0)
+					damage *= players[victim].crit_flag ? 1.0 : 0.45; // for crits and minicrits, respectively
+					// I am not sure if the old Phlog defense buff taunt had damage resistance againt minicrits. 
+					// I will assume it has 55% damage resistance (90-35=55, 100-55=45).
+				else
+					damage *= 0.10;
+
+				// to do: add taunt kill immunity (must resist 500 damage)
+
+				returnValue = Plugin_Changed;
 			}
 		}
 	}

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -806,7 +806,7 @@
 	}
 	"Phlog_TB"
 	{
-		"en"	"Reverted to Tough Break, activating MMMPH instantly restores to full health, MMMPH requires lower fire damage (225)"
+		"en"	"Reverted to Tough Break, activating MMMPH instantly restores to full health, Ubered a bit after taunting, MMMPH requires lower fire damage (225)"
 	}
 	"Phlog_Release"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -810,7 +810,7 @@
 	}
 	"Phlog_Release"
 	{
-		"en"	"Reverted to release, activating MMMPH instantly restores to full health with 90%% dmg resist and no Uber while taunting, MMMPH requires lower fire damage (225), longer 12 sec crit buff"
+		"en"	"Reverted to release, activating MMMPH instantly restores to full health with 90%% dmg resist and no Uber while taunting, MMMPH requires lower fire damage (225), longer 13 sec crit buff"
 	}
 	"Pomson_PreGM"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -334,6 +334,10 @@
 	{
 		"en"	"Persian Persuader"
 	}
+	"phlogistinator"
+	{
+		"en"	"Phlogistinator"
+	}
 	"pomson"
 	{
 		"en"	"Pomson 6000"
@@ -795,6 +799,18 @@
 	"Persuader_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, picks up ammo as health, +100%% charge recharge rate, no max ammo penalty"
+	}
+	"Phlog_Pyro"
+	{
+		"en"	"Reverted to Pyromania, activating MMMPH instantly restores to full health with 75%% dmg resist and no Uber while taunting, MMMPH requires lower fire damage (225), -10%% dmg penalty"
+	}
+	"Phlog_TB"
+	{
+		"en"	"Reverted to Tough Break, activating MMMPH instantly restores to full health, MMMPH requires lower fire damage (225)"
+	}
+	"Phlog_Release"
+	{
+		"en"	"Reverted to release, activating MMMPH instantly restores to full health with 90%% dmg resist and no Uber while taunting, MMMPH requires lower fire damage (225), longer 12 sec crit buff"
 	}
 	"Pomson_PreGM"
 	{


### PR DESCRIPTION
### Summary of changes
#### Pyromania Phlogistinator (Variant 0)
Video reference: https://www.youtube.com/watch?v=D5Et9qhxDvQ
Wiki: https://wiki.teamfortress.com/w/index.php?title=Phlogistinator&oldid=1968959
- MMMPH meter requires 225 damage
- Instantly restores health to max during activation
- -10% damage penalty
- No invulnerability on MMMPH
- 75% damage resistance while taunting (25% against crits)

#### Tough Break Phlogistinator (Variant 1)
Video reference: https://www.youtube.com/watch?v=9cMTp4xd1R8
Wiki: https://wiki.teamfortress.com/w/index.php?title=Phlogistinator&oldid=2035615
- MMMPH meter requires 225 damage
- Instantly restores health to max during activation
- Invulnerability lingers a bit right after taunt ends

#### Release Phlogistinator (Variant 2)
Wiki: https://wiki.teamfortress.com/w/index.php?title=Phlogistinator&oldid=967378
- MMMPH meter requires 225 damage
- Instantly restores health to max during activation
- No invulnerability on MMMPH
- 90% damage resistance while taunting (30% against crits)
- 13 seconds long MMMPH crit buff

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
itemtest with bots

### Other Info
Imported MMMPH meter revert from NotnHeavy's plugin
Tough Break and Release Phlog variants could be the most powerful versions of the Phlog
