### PR TITLE
(Reverts) Short Circuit: ignore spawn barriers when destroying projectiles

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -5133,6 +5133,13 @@ bool TraceFilter_CustomShortCircuit(int entity, int contentsmask, any data) {
 		return false;
 	}
 
+	// ignore respawn room visualizers
+	if (StrEqual(class, "func_respawnroomvisualizer")) {
+		return false;
+	}
+
+	//PrintToChatAll("Short Circuit trace hit blocked by %s", class);
+
 	return true;
 }
 


### PR DESCRIPTION
### Summary of changes
Fixes projectiles not being destroyed when a spawn barrier is in the way. Makes clearing sticky traps more effective

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway, the sides of the track are spawn barriers

### Other Info
N/A
