### PR TITLE
(Reverts) Add more item variants 3

### DIFF
--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -59,7 +59,7 @@ sm_reverts__item_gardener 1
 sm_reverts__item_natascha 1
 sm_reverts__item_panic 1
 sm_reverts__item_persuader 1
-sm_reverts__item_phlogistinator 0
+sm_reverts__item_phlog 0
 sm_reverts__item_pomson 1
 sm_reverts__item_powerjack 1
 sm_reverts__item_pocket 1

--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -4,6 +4,7 @@
 sm_reverts__old_falldmg_sfx 1
 sm_reverts__enable_dropped_weapon 1
 sm_reverts__pre_toughbreak_switch 0
+sm_reverts__enable_shortstop_shove 1
 sm_reverts__show_moonshot 1
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
@@ -27,7 +28,7 @@ sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
 sm_reverts__item_carbine 1
 sm_reverts__item_concheror 1
-sm_reverts__item_cowmangler 1
+sm_reverts__item_cowmangler 0
 sm_reverts__item_cozycamper 1
 sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 0
@@ -58,6 +59,7 @@ sm_reverts__item_gardener 1
 sm_reverts__item_natascha 1
 sm_reverts__item_panic 1
 sm_reverts__item_persuader 1
+sm_reverts__item_phlogistinator 0
 sm_reverts__item_pomson 1
 sm_reverts__item_powerjack 1
 sm_reverts__item_pocket 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -38,7 +38,8 @@ sm_reverts__item_carbine 2
 sm_reverts__item_concheror 1
 sm_reverts__item_cowmangler 0
 // pre-GM cow mangler had 4 shots, this is the closest
-sm_reverts__item_cozycamper 3
+sm_reverts__item_cozycamper 0
+// cozycamper lacks pre-GM version (has +1 HP/s flat regen and increased 20% dmg taken)
 sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 0
 sm_reverts__item_dalokohsbar 0

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -9,6 +9,7 @@
 sm_reverts__old_falldmg_sfx 1
 sm_reverts__enable_dropped_weapon 1
 sm_reverts__pre_toughbreak_switch 1
+sm_reverts__enable_shortstop_shove 0
 sm_reverts__item_airblast 1
 // note: airblast revert is not 100% accurate due to different hitboxes
 sm_reverts__item_airstrike 0
@@ -29,7 +30,7 @@ sm_reverts__item_booties 0
 // booties lacks pre-GM version (no +10% movement speed bonus)
 sm_reverts__item_brassbeast 0
 // brassbeast lacks pre-GM version (no 20% dmg resist on spin)
-sm_reverts__item_bushwacka 0
+sm_reverts__item_bushwacka 2
 sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
 sm_reverts__item_claidheamh 1
@@ -37,8 +38,7 @@ sm_reverts__item_carbine 2
 sm_reverts__item_concheror 1
 sm_reverts__item_cowmangler 0
 // pre-GM cow mangler had 4 shots, this is the closest
-sm_reverts__item_cozycamper 0
-// cozycamper lacks pre-GM version (has increased 20% dmg taken)
+sm_reverts__item_cozycamper 3
 sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 0
 sm_reverts__item_dalokohsbar 0

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2331,6 +2331,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				// no crit boost attribute fix handled elsewhere in SDKHookCB_OnTakeDamage
 			}
 		}}
+#if defined MEMORY_PATCHES
 		case 642: { if (ItemIsEnabled(Wep_CozyCamper)) {
 			switch (GetItemVariant(Wep_CozyCamper)) {
 				case 1: {
@@ -2349,6 +2350,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				}
 			}
 		}}
+#endif
 		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
 			switch (GetItemVariant(Wep_CritCola)) {
 				case 0, 1, 2: {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -507,9 +507,6 @@ public void OnPluginStart() {
 	ItemVariant(Wep_CowMangler, "CowMangler_Pre2013");
 #if defined MEMORY_PATCHES
 	ItemDefine("cozycamper", "CozyCamper_PreMYM", CLASSFLAG_SNIPER, Wep_CozyCamper, true);
-	ItemVariant(Wep_CozyCamper, "CozyCamper_PreTB");
-	ItemVariant(Wep_CozyCamper, "CozyCamper_PreGM");
-	ItemVariant(Wep_CozyCamper, "CozyCamper_Pre2013");
 #endif
 	ItemDefine("critcola", "CritCola_PreMYM", CLASSFLAG_SCOUT, Wep_CritCola);
 	ItemVariant(Wep_CritCola, "CritCola_PreJI");
@@ -2331,26 +2328,6 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 				// no crit boost attribute fix handled elsewhere in SDKHookCB_OnTakeDamage
 			}
 		}}
-#if defined MEMORY_PATCHES
-		case 642: { if (ItemIsEnabled(Wep_CozyCamper)) {
-			switch (GetItemVariant(Wep_CozyCamper)) {
-				case 1: {
-					TF2Items_SetNumAttributes(itemNew, 1);
-					TF2Items_SetAttribute(itemNew, 0, 57, 1.00); // +1 health regenerated per second on wearer
-				}
-				case 2: {
-					TF2Items_SetNumAttributes(itemNew, 2);
-					TF2Items_SetAttribute(itemNew, 0, 57, 1.00); // +1 health regenerated per second on wearer
-					TF2Items_SetAttribute(itemNew, 1, 412, 1.20); // 20% damage vulnerability on wearer
-				}
-				case 3: {
-					TF2Items_SetNumAttributes(itemNew, 2);
-					TF2Items_SetAttribute(itemNew, 0, 57, 1.00); // +1 health regenerated per second on wearer
-					TF2Items_SetAttribute(itemNew, 1, 378, 0.20); // 80% slower move speed when aiming
-				}
-			}
-		}}
-#endif
 		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
 			switch (GetItemVariant(Wep_CritCola)) {
 				case 0, 1, 2: {
@@ -6387,24 +6364,6 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 				full_regen = true;
 			}
 		}
-
-#if defined MEMORY_PATCHES
-		if (GetItemVariant(Wep_CozyCamper) > 0) {
-			// Loop through wearables
-			int num_wearables = TF2Util_GetPlayerWearableCount(client);
-			for (int i = 0; i < num_wearables; i++)
-			{
-				int wearable = TF2Util_GetPlayerWearable(client, i);
-				int index = GetEntProp(wearable, Prop_Send, "m_iItemDefinitionIndex");
-
-				if (index == 642) {
-					// Player has a Cozy Camper, fake MvM game state for full regen
-					full_regen = true;
-					break;
-				}
-			}
-		}
-#endif
 
 		if (full_regen) {
 			prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -6387,10 +6387,7 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 		}
 
 #if defined MEMORY_PATCHES
-		if (
-			ItemIsEnabled(Wep_CozyCamper) &&
-			GetItemVariant(Wep_CozyCamper) != 0
-		) {
+		if (GetItemVariant(Wep_CozyCamper) > 0) {
 			// Loop through wearables
 			int num_wearables = TF2Util_GetPlayerWearableCount(client);
 			for (int i = 0; i < num_wearables; i++)

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -455,7 +455,7 @@ public void OnPluginStart() {
 
 	cvar_enable = CreateConVar("sm_reverts__enable", "1", (PLUGIN_NAME ... " - Enable plugin"), _, true, 0.0, true, 1.0);
 	cvar_show_moonshot = CreateConVar("sm_reverts__show_moonshot", "0", (PLUGIN_NAME ... " - Show a HUD message when someone lands a moonshot"), _, true, 0.0, true, 1.0);
-	cvar_old_falldmg_sfx = CreateConVar("sm_reverts__old_falldmg_sfx", "1", (PLUGIN_NAME ... " - Enable old (pre-inferno) fall damage sound (old bone crunch, no hurt voicelines)"), _, true, 0.0, true, 1.0);
+	cvar_old_falldmg_sfx = CreateConVar("sm_reverts__old_falldmg_sfx", "0", (PLUGIN_NAME ... " - Enable old (pre-inferno) fall damage sound (old bone crunch, no hurt voicelines)"), _, true, 0.0, true, 1.0);
 #if defined MEMORY_PATCHES
 	cvar_dropped_weapon_enable = CreateConVar("sm_reverts__enable_dropped_weapon", "0", (PLUGIN_NAME ... " - Revert dropped weapon behaviour"), _, true, 0.0, true, 1.0);
 #endif

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -494,6 +494,7 @@ public void OnPluginStart() {
 	ItemDefine("booties", "Booties_PreMYM", CLASSFLAG_DEMOMAN, Wep_Booties);
 	ItemDefine("brassbeast", "BrassBeast_PreMYM", CLASSFLAG_HEAVY, Wep_BrassBeast);
 	ItemDefine("bushwacka", "Bushwacka_PreLW", CLASSFLAG_SNIPER, Wep_Bushwacka);
+	ItemVariant(Wep_Bushwacka, "Bushwacka_PreGM");
 	ItemDefine("buffalosteak", "BuffaloSteak_PreMYM", CLASSFLAG_HEAVY, Wep_BuffaloSteak);
 	ItemVariant(Wep_BuffaloSteak, "BuffaloSteak_Release");
 	ItemVariant(Wep_BuffaloSteak, "BuffaloSteak_Pre2013");
@@ -505,7 +506,10 @@ public void OnPluginStart() {
 	ItemDefine("cowmangler", "CowMangler_Release", CLASSFLAG_SOLDIER, Wep_CowMangler);
 	ItemVariant(Wep_CowMangler, "CowMangler_Pre2013");
 #if defined MEMORY_PATCHES
-	ItemDefine("cozycamper","CozyCamper_PreMYM", CLASSFLAG_SNIPER, Wep_CozyCamper, true);
+	ItemDefine("cozycamper", "CozyCamper_PreMYM", CLASSFLAG_SNIPER, Wep_CozyCamper, true);
+	ItemVariant(Wep_CozyCamper, "CozyCamper_PreTB");
+	ItemVariant(Wep_CozyCamper, "CozyCamper_PreGM");
+	ItemVariant(Wep_CozyCamper, "CozyCamper_Pre2013");
 #endif
 	ItemDefine("critcola", "CritCola_PreMYM", CLASSFLAG_SCOUT, Wep_CritCola);
 	ItemVariant(Wep_CritCola, "CritCola_PreJI");
@@ -583,12 +587,14 @@ public void OnPluginStart() {
 	ItemDefine("quickfix", "Quickfix_PreMYM", CLASSFLAG_MEDIC, Wep_QuickFix);
 #endif
 	ItemDefine("quickiebomb", "Quickiebomb_PreMYM", CLASSFLAG_DEMOMAN | ITEMFLAG_DISABLED, Wep_Quickiebomb);
-	ItemDefine("razorback","Razorback_PreJI", CLASSFLAG_SNIPER, Wep_Razorback);
-	ItemDefine("redtape","RedTapeRecorder_Release", CLASSFLAG_SPY | ITEMFLAG_DISABLED, Wep_RedTapeRecorder);
+	ItemDefine("razorback", "Razorback_PreJI", CLASSFLAG_SNIPER, Wep_Razorback);
+	ItemDefine("redtape", "RedTapeRecorder_Release", CLASSFLAG_SPY | ITEMFLAG_DISABLED, Wep_RedTapeRecorder);
 	ItemDefine("rescueranger", "RescueRanger_PreGM", CLASSFLAG_ENGINEER, Wep_RescueRanger);
 	ItemVariant(Wep_RescueRanger, "RescueRanger_PreJI");
+	ItemVariant(Wep_RescueRanger, "RescueRanger_Release");
 	ItemDefine("reserve", "Reserve_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_PYRO, Wep_ReserveShooter);
 	ItemVariant(Wep_ReserveShooter, "Reserve_PreJI");
+	ItemVariant(Wep_ReserveShooter, "Reserve_Release");
 	ItemDefine("bison", "Bison_PreMYM", CLASSFLAG_SOLDIER, Wep_Bison);
 	ItemVariant(Wep_Bison, "Bison_PreTB");
 	ItemDefine("rocketjmp", "RocketJmp_Pre2013", CLASSFLAG_SOLDIER, Wep_RocketJumper);
@@ -2247,11 +2253,21 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			// mini-crits on damage taken handled elsewhere in TF2_OnConditionAdded and TF2_OnConditionRemoved
 		}}
 		case 232: { if (ItemIsEnabled(Wep_Bushwacka)) {
-			TF2Items_SetNumAttributes(itemNew, 4);
-			TF2Items_SetAttribute(itemNew, 0, 128, 0.0); // provide on active
-			TF2Items_SetAttribute(itemNew, 1, 412, 1.00); // 0% damage vulnerability on wearer
-			TF2Items_SetAttribute(itemNew, 2, 15, 1.0); // random crits enabled
-			TF2Items_SetAttribute(itemNew, 3, 61, 1.20); // 20% fire damage vulnerability on wearer
+			switch (GetItemVariant(Wep_Bushwacka)) {
+				case 1: {
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 61, 1.20); // 20% fire damage vulnerability on wearer
+					TF2Items_SetAttribute(itemNew, 1, 128, 0.0); // provide on active
+					TF2Items_SetAttribute(itemNew, 2, 412, 1.00); // 0% damage vulnerability on wearer
+				}
+				default: {
+					TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetAttribute(itemNew, 0, 15, 1.0); // random crits enabled
+					TF2Items_SetAttribute(itemNew, 1, 61, 1.20); // 20% fire damage vulnerability on wearer
+					TF2Items_SetAttribute(itemNew, 2, 128, 0.0); // provide on active
+					TF2Items_SetAttribute(itemNew, 3, 412, 1.00); // 0% damage vulnerability on wearer
+				}
+			}
 		}}
 		case 307: { if (ItemIsEnabled(Wep_Caber)) {
 			TF2Items_SetNumAttributes(itemNew, 2);
@@ -2313,6 +2329,24 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 4, 1, 0.90); // mult_dmg; 10% damage penalty
 				}
 				// no crit boost attribute fix handled elsewhere in SDKHookCB_OnTakeDamage
+			}
+		}}
+		case 642: { if (ItemIsEnabled(Wep_CozyCamper)) {
+			switch (GetItemVariant(Wep_CozyCamper)) {
+				case 1: {
+					TF2Items_SetNumAttributes(itemNew, 1);
+					TF2Items_SetAttribute(itemNew, 0, 57, 1.00); // +1 health regenerated per second on wearer
+				}
+				case 2: {
+					TF2Items_SetNumAttributes(itemNew, 2);
+					TF2Items_SetAttribute(itemNew, 0, 57, 1.00); // +1 health regenerated per second on wearer
+					TF2Items_SetAttribute(itemNew, 1, 412, 1.20); // 20% damage vulnerability on wearer
+				}
+				case 3: {
+					TF2Items_SetNumAttributes(itemNew, 2);
+					TF2Items_SetAttribute(itemNew, 0, 57, 1.00); // +1 health regenerated per second on wearer
+					TF2Items_SetAttribute(itemNew, 1, 378, 0.20); // 80% slower move speed when aiming
+				}
 			}
 		}}
 		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
@@ -2644,16 +2678,37 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			TF2Items_SetNumAttributes(itemNew, 1);
 			TF2Items_SetAttribute(itemNew, 0, 433, 0.9); // Downgrade speed; sapper_degenerates_buildings; default is 0.5 (3 seconds). release was 1.6 seconds (0.9 according to https://wiki.teamfortress.com/wiki/August_2,_2012_Patch)
 		}}
-		case 997: { if (GetItemVariant(Wep_RescueRanger) == 0) {
-			TF2Items_SetNumAttributes(itemNew, 2);
-			TF2Items_SetAttribute(itemNew, 0, 469, 130.0); // ranged pickup metal cost
-			TF2Items_SetAttribute(itemNew, 1, 474, 75.0); // repair bolt healing amount
+		case 997: { if (ItemIsEnabled(Wep_RescueRanger)) {
+			switch (GetItemVariant(Wep_RescueRanger)) {
+				case 0: {
+					TF2Items_SetNumAttributes(itemNew, 2);
+					TF2Items_SetAttribute(itemNew, 0, 469, 130.0); // ranged pickup metal cost
+					TF2Items_SetAttribute(itemNew, 1, 474, 75.0); // repair bolt healing amount
+				}
+				case 2: {
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 469, 130.0); // ranged pickup metal cost
+					TF2Items_SetAttribute(itemNew, 1, 474, 50.0); // repair bolt healing amount
+					TF2Items_SetAttribute(itemNew, 2, 476, 0.875); // -12.5% damage penalty (hidden, for 35 base damage)
+				}
+			}
 		}}
-		case 415: { if (GetItemVariant(Wep_ReserveShooter) == 0) {
-			TF2Items_SetNumAttributes(itemNew, 3);
-			TF2Items_SetAttribute(itemNew, 0, 114, 0.0); // mod mini-crit airborne
-			TF2Items_SetAttribute(itemNew, 1, 178, 0.85); // 15% faster weapon switch
-			TF2Items_SetAttribute(itemNew, 2, 547, 1.0); // This weapon deploys 0% faster
+		case 415: { if (ItemIsEnabled(Wep_ReserveShooter)) {
+			switch (GetItemVariant(Wep_ReserveShooter)) {
+				case 0: {
+					TF2Items_SetNumAttributes(itemNew, 3);
+					TF2Items_SetAttribute(itemNew, 0, 114, 0.0); // mod mini-crit airborne
+					TF2Items_SetAttribute(itemNew, 1, 178, 0.85); // 15% faster weapon switch
+					TF2Items_SetAttribute(itemNew, 2, 547, 1.0); // This weapon deploys 0% faster
+				}
+				case 2: {
+					TF2Items_SetNumAttributes(itemNew, 4);
+					TF2Items_SetAttribute(itemNew, 0, 3, 0.50); // -50% clip size
+					TF2Items_SetAttribute(itemNew, 1, 114, 0.0); // mod mini-crit airborne
+					TF2Items_SetAttribute(itemNew, 2, 178, 0.85); // 15% faster weapon switch
+					TF2Items_SetAttribute(itemNew, 3, 547, 1.0); // This weapon deploys 0% faster
+				}
+			}
 		}}
 		case 59: { if (ItemIsEnabled(Wep_DeadRinger)) {
 			switch (GetItemVariant(Wep_DeadRinger)) {
@@ -3247,7 +3302,6 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 			for (int i = 0; i < num_wearables; i++)
 			{
 				int wearable = TF2Util_GetPlayerWearable(client, i);
-				GetEntityClassname(wearable, class, sizeof(class));
 				index = GetEntProp(wearable,Prop_Send,"m_iItemDefinitionIndex");
 
 				switch (index) {
@@ -4145,7 +4199,9 @@ Action SDKHookCB_OnTakeDamage(
 							(GetItemVariant(Wep_ReserveShooter) == 0 &&
 							(players[attacker].ticks_since_switch < 66 * 5)) ||
 							(GetItemVariant(Wep_ReserveShooter) == 1 &&
-							TF2_IsPlayerInCondition(victim, TFCond_KnockedIntoAir) == true)
+							TF2_IsPlayerInCondition(victim, TFCond_KnockedIntoAir) == true) ||
+							(GetItemVariant(Wep_ReserveShooter) == 2 &&
+							(players[attacker].ticks_since_switch < 66 * 3))
 						) {
 							// seems to be the best way to force a minicrit
 							TF2_AddCondition(victim, TFCond_MarkedForDeathSilent, 0.001, 0);
@@ -6294,6 +6350,7 @@ MRESReturn DHookCallback_CTFAmmoPack_MakeHolidayPack(int pThis) {
 MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 {
 	int weapon;
+	bool full_regen = false;
 
 	// Don't proceed if in MvM
     if (cvar_ref_tf_gamemode_mvm.BoolValue)
@@ -6311,11 +6368,8 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 			weapon > 0
 		) {
 			if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 354) {
-				// Weapon is a Concheror, so fake MvM game state for full regen
-				prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
-				GameRules_SetProp("m_bPlayingMannVsMachine", 1);
-				regen_think_override = true;
-				return MRES_Ignored;
+				// Weapon is a Concheror, fake MvM game state for full regen
+				full_regen = true;
 			}
 		}
 	
@@ -6327,12 +6381,37 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Pre(int client)
 			weapon > 0
 		) {
 			if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 304) {
-				// Weapon is an Amputator, so fake MvM game state for full regen
-				prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
-				GameRules_SetProp("m_bPlayingMannVsMachine", 1);
-				regen_think_override = true;
-				return MRES_Ignored;
+				// Weapon is an Amputator, fake MvM game state for full regen
+				full_regen = true;
 			}
+		}
+
+#if defined MEMORY_PATCHES
+		if (
+			ItemIsEnabled(Wep_CozyCamper) &&
+			GetItemVariant(Wep_CozyCamper) != 0
+		) {
+			// Loop through wearables
+			int num_wearables = TF2Util_GetPlayerWearableCount(client);
+			for (int i = 0; i < num_wearables; i++)
+			{
+				int wearable = TF2Util_GetPlayerWearable(client, i);
+				int index = GetEntProp(wearable, Prop_Send, "m_iItemDefinitionIndex");
+
+				if (index == 642) {
+					// Player has a Cozy Camper, fake MvM game state for full regen
+					full_regen = true;
+					break;
+				}
+			}
+		}
+#endif
+
+		if (full_regen) {
+			prev_mvm_state = GameRules_GetProp("m_bPlayingMannVsMachine");
+			GameRules_SetProp("m_bPlayingMannVsMachine", 1);
+			regen_think_override = true;
+			return MRES_Ignored;
 		}
 	}
 	

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -608,18 +608,6 @@
 	{
 		"en"	"Reverted to pre-matchmaking, flinch resist at any charge level"
 	}
-	"CozyCamper_PreTB"
-	{
-		"en"	"Reverted to pre-toughbreak, flinch resist at any charge level, +1 HP/s regen"
-	}
-	"CozyCamper_PreGM"
-	{
-		"en"	"Reverted to pre-gunmettle, flinch resist at any charge level, +1 HP/s regen, 20%% dmg vuln"
-	}
-	"CozyCamper_Pre2013"
-	{
-		"en"	"Reverted to pre-Summer 2013, flinch resist at any charge level, +1 HP/s regen, -80%% movespeed when aiming"
-	}
 	"CritCola_PreMYM"
 	{
 		"en"	"Reverted to pre-matchmaking, +25%% movespeed, +10%% damage taken, no mark-for-death on attack"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -894,7 +894,7 @@
 	}
 	"RescueRanger_Release"
 	{
-		"en"	"Reverted to release, heals +50 flat for no metal cost, 130 cost long-range pickups, 35 base dmg"
+		"en"	"Reverted to release, heals +50 flat for no metal cost, 130 cost long-range pickups, 35 base dmg (from 40)"
 	}
 	"Reserve_PreTB"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -560,6 +560,10 @@
 	{
 		"en"	"Reverted to pre-love&war, 20%% fire vuln at all times, random crits enabled"
 	}
+	"Bushwacka_PreGM"
+	{
+		"en"	"Reverted to pre-gunmettle, 20%% fire vuln at all times instead of dmg vuln when active"
+	}
 	"BuffaloSteak_PreMYM"
 	{
 		"en"	"Reverted to pre-matchmaking, immediately gain +35%% faster move speed and 10%% dmg vuln while buffed"
@@ -603,6 +607,18 @@
 	"CozyCamper_PreMYM"
 	{
 		"en"	"Reverted to pre-matchmaking, flinch resist at any charge level"
+	}
+	"CozyCamper_PreTB"
+	{
+		"en"	"Reverted to pre-toughbreak, flinch resist at any charge level, +1 HP/s regen"
+	}
+	"CozyCamper_PreGM"
+	{
+		"en"	"Reverted to pre-gunmettle, flinch resist at any charge level, +1 HP/s regen, 20%% dmg vuln"
+	}
+	"CozyCamper_Pre2013"
+	{
+		"en"	"Reverted to pre-Summer 2013, flinch resist at any charge level, +1 HP/s regen, -80%% movespeed when aiming"
 	}
 	"CritCola_PreMYM"
 	{
@@ -870,11 +886,15 @@
 	}
 	"RescueRanger_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, heals +75 flat, no metal cost, 130 cost long ranged pickups"
+		"en"	"Reverted to pre-gunmettle, heals +75 flat for no metal cost, 130 cost long-range pickups"
 	}
 	"RescueRanger_PreJI"
 	{
 		"en"	"Reverted to pre-inferno, no metal cost for healing buildings"
+	}
+	"RescueRanger_Release"
+	{
+		"en"	"Reverted to release, heals +50 flat for no metal cost, 130 cost long-range pickups, 35 base dmg"
 	}
 	"Reserve_PreTB"
 	{
@@ -883,6 +903,10 @@
 	"Reserve_PreJI"
 	{
 		"en"	"Reverted to pre-inferno, deals minicrits to airblasted targets again"
+	}
+	"Reserve_Release"
+	{
+		"en"	"Reverted to release, minicrits all airborne targets for 3 sec after deploying, 15%% faster weapon switch, -50%% clip size"
 	}
 	"Bison_PreMYM"
 	{


### PR DESCRIPTION
### Summary of changes
Pre-GM Bushwacka
~~Pre-TB, Pre-GM and Pre-2013 Cozy Camper~~ (removed)
Release Rescue Ranger
Release Reserve Shooter

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested with bots

### Other Info
disable old falldmg sfx by default, now follows the same convention with the other 'cosmetic' cvars
conch and amputator reverts no longer fake mvm but use involved logic (for preventing any case where the mvm game state isn't cleared out properly and server closes due to not enough player slots)