### PR TITLE
(Reverts) Reverted DR cloak cap improvement

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1834,7 +1834,7 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 					players[client].feign_ready_tick > 0
 				) {
 					// undo 50% drain on activated
-					SetEntPropFloat(client, Prop_Send, "m_flCloakMeter", cloak + 50.0);
+					SetEntPropFloat(client, Prop_Send, "m_flCloakMeter", floatMin(cloak + 50.0, 100.0));
 				}
 			}
 

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1455,22 +1455,22 @@ public void OnGameFrame() {
 						cloak = GetEntPropFloat(idx, Prop_Send, "m_flCloakMeter");
 
 						if (GetItemVariant(Wep_DeadRinger) == 0) {
-							if (
-								(cloak - players[idx].spy_cloak_meter) > 35.0 &&
-								(players[idx].ammo_grab_frame + 1) == GetGameTickCount()
-							) {
-								weapon = GetPlayerWeaponSlot(idx, TFWeaponSlot_Building);
+							weapon = GetPlayerWeaponSlot(idx, TFWeaponSlot_Building);
 
-								if (weapon > 0) {
-									GetEntityClassname(weapon, class, sizeof(class));
+							if (weapon > 0) {
+								GetEntityClassname(weapon, class, sizeof(class));
 
+								if (
+									StrEqual(class, "tf_weapon_invis") &&
+									GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 59
+								) {
 									if (
-										StrEqual(class, "tf_weapon_invis") &&
-										GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 59
+										(cloak - players[idx].spy_cloak_meter) > 35.0 &&
+										(players[idx].ammo_grab_frame + 1) == GetGameTickCount()
 									) {
 										// ammo boxes only give 35% cloak max
 										cloak = (players[idx].spy_cloak_meter + 35.0);
-										SetEntPropFloat(idx, Prop_Send, "m_flCloakMeter", cloak);
+										SetEntPropFloat(idx, Prop_Send, "m_flCloakMeter", cloak);	
 									}
 									TF2Attrib_RemoveByDefIndex(weapon, 729);
 								}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -6127,8 +6127,10 @@ MRESReturn DHookCallback_CAmmoPack_MyTouch(int entity, DHookReturn returnValue, 
 		client <= MaxClients
 	) {
 		int pack_size = SDKCall(sdkcall_CAmmoPack_GetPowerupSize, entity);
-		if (TF2Attrib_HookValueInt(0, "ammo_becomes_health", client) == 1)
-		{
+		if (
+			ItemIsEnabled(Wep_Persian) &&
+			TF2Attrib_HookValueInt(0, "ammo_becomes_health", client) == 1
+		) {
 			// Health pickup with the Persian Persuader.
 			returnValue.Value = false;
 			int health = GetClientHealth(client);
@@ -6184,7 +6186,10 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
 		client > 0 &&
 		client <= MaxClients
 	) {
-		if (TF2Attrib_HookValueInt(0, "ammo_becomes_health", client) == 1) {
+		if (
+			ItemIsEnabled(Wep_Persian) &&
+			TF2Attrib_HookValueInt(0, "ammo_becomes_health", client) == 1
+		) {
 			// Health pickup with the Persian Persuader from dropped ammo packs.
 			int health = GetClientHealth(client);
 			int health_max = SDKCall(sdkcall_GetMaxHealth, client);


### PR DESCRIPTION
### Summary of changes
gaining cloak via ammo box no longer overshoots with reverted dead ringer
use attribute hook for persian persuader
compensate damage for initial hit with pre-war sandman

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on walkway and itemtest

### Other Info
N/A
