### PR TITLE
(Reverts) Various fixes/improvements 3

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -98,6 +98,12 @@
 				"windows" "396"
 				"linux"	  "396"
 			}
+
+			"CObjectDispenser::DispenseAmmo"
+			{
+				"linux" "425"
+				"windows" "411"
+			}
 		}
 
 		"Functions"
@@ -129,6 +135,21 @@
 			"CAmmoPack::MyTouch"
 			{
 				"offset"   "CAmmoPack::MyTouch"
+				"hooktype" "entity"
+				"this"     "entity"
+				"return"   "bool"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type" "int"
+					}
+				}
+			}
+
+			"CObjectDispenser::DispenseAmmo"
+			{
+				"offset"	"CObjectDispenser::DispenseAmmo"
 				"hooktype" "entity"
 				"this"     "entity"
 				"return"   "bool"
@@ -238,7 +259,7 @@
 				"callconv"  "thiscall"
 				"this"      "entity"
 				"return"    "void"
-			}	
+			}
 		}
 	}
 }

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -58,15 +58,7 @@
 				"library" "server"
 				"windows" "\x55\x8B\xEC\x83\xEC\x7C\x56\x8B\xF1\x8B\x06"
 				"linux"   "@_ZN9CTFPlayer10RegenThinkEv"
-			}
-
-			// "CTFPlayerShared::ModifyRage"
-			"CTFPlayerShared::SetRageMeter" // aRageOnHit "rage_on_hit", go to subroutine call after SIMD instruction ~~go to subroutine (2nd line down previously) that is just a one-liner func call~~
-			{
-				"library" "server"
-				"windows" "\x55\x8B\xEC\xF3\x0F\x10\x45\x08\x83\xEC\x08"
-				"linux"	  "@_ZN15CTFPlayerShared12SetRageMeterEf"
-			}			
+			}		
 		}
 
 		"Offsets"
@@ -246,23 +238,7 @@
 				"callconv"  "thiscall"
 				"this"      "entity"
 				"return"    "void"
-			}
-
-			//"CTFPlayerShared::ModifyRage"
-			"CTFPlayerShared::SetRageMeter"
-			{
-				"signature" "CTFPlayerShared::SetRageMeter"
-				"callconv"  "thiscall"
-				"this"      "address"
-				"return"    "void"
-				"arguments"
-				{
-					"fDelta"
-					{
-						"type" "float"
-					}
-				}
-			}			
+			}	
 		}
 	}
 }

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -58,7 +58,7 @@
 				"library" "server"
 				"windows" "\x55\x8B\xEC\x83\xEC\x7C\x56\x8B\xF1\x8B\x06"
 				"linux"   "@_ZN9CTFPlayer10RegenThinkEv"
-			}		
+			}
 		}
 
 		"Offsets"

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4731,7 +4731,7 @@ Action SDKHookCB_OnTakeDamageAlive(
 					weapon > 0
 				) {
 					if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 230) {
-						// Restore sleeper attrib for pre-MyM variant
+						// Restore sleeper attrib
 						TF2Attrib_SetByDefIndex(weapon, 175, 8.0);
 					}
 				}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1992,24 +1992,24 @@ public void TF2_OnConditionAdded(int client, TFCond condition) {
 				SetEntProp(client, Prop_Send, "m_iHealth", health_max);
 			}
 
-			switch(GetItemVariant(Wep_Phlogistinator)) {
+			switch (GetItemVariant(Wep_Phlogistinator)) {
 				case 0: { // Pyromania Phlog
-				TF2_AddCondition(client, TFCond_InHealRadius, 3.0, 0); // re-add healing circle visual effect
-				TF2_AddCondition(client, TFCond_DefenseBuffMmmph, 3.0, 0);
+					TF2_AddCondition(client, TFCond_InHealRadius, 3.0, 0); // re-add healing circle visual effect
+					TF2_AddCondition(client, TFCond_DefenseBuffMmmph, 3.0, 0);
 				}
 				case 1: { // Tough Break Phlog
-				// a bit of Uber left over when taunt ends for historical accuracy. i am not sure how exactly long it was, this is just a guess.
-				TF2_AddCondition(client, TFCond_UberchargedCanteen, 3.5, 0);
+					// a bit of Uber left over when taunt ends for historical accuracy. i am not sure how exactly long it was, this is just a guess.
+					TF2_AddCondition(client, TFCond_UberchargedCanteen, 3.5, 0);
 				}
 				case 2: { // Release Phlog
-				// changelog says 12 seconds, but the wiki says 13 seconds. I'll set it to 13 instead because of the taunt duration.
-				TF2_AddCondition(client, TFCond_InHealRadius, 3.0, 0); // re-add healing circle visual effect
-				TF2_AddCondition(client, TFCond_CritMmmph, 13.0, 0);
-				// 90% defense buff handled elsewhere in OnTakeDamageAlive
+					// changelog says 12 seconds, but the wiki says 13 seconds. I'll set it to 13 instead because of the taunt duration.
+					TF2_AddCondition(client, TFCond_InHealRadius, 3.0, 0); // re-add healing circle visual effect
+					TF2_AddCondition(client, TFCond_CritMmmph, 13.0, 0);
+					// 90% defense buff handled elsewhere in OnTakeDamageAlive
 				}
 				case 3: { // March 15, 2012 Phlog
-				TF2_AddCondition(client, TFCond_InHealRadius, 3.0, 0); // re-add healing circle visual effect
-				// 90% defense buff handled elsewhere in OnTakeDamageAlive
+					TF2_AddCondition(client, TFCond_InHealRadius, 3.0, 0); // re-add healing circle visual effect
+					// 90% defense buff handled elsewhere in OnTakeDamageAlive
 				}
 			}			
 		}
@@ -2122,7 +2122,7 @@ public Action TF2_OnAddCond(int client, TFCond &condition, float &time, int &pro
 		// prevent Phlog uber and knockback immunity for Release, Pyromania, and March 2012 variants
 		// also prevents removal of debuffs when taunting (e.g. jarate gets removed because of the uber effect)
 		if (
-			(GetItemVariant(Wep_Phlogistinator) == 0 || GetItemVariant(Wep_Phlogistinator) == 2 || GetItemVariant(Wep_Phlogistinator) == 3) &&
+			ItemIsEnabled(Wep_Phlogistinator) && GetItemVariant(Wep_Phlogistinator) != 1 &&
 			TF2_GetPlayerClass(client) == TFClass_Pyro
 		) {
 			// Prevent Uber effect (should also prevent debuff removal)

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -838,12 +838,12 @@ public void OnPluginStart() {
 	dhook_CTFPlayer_CalculateMaxSpeed.Enable(Hook_Post, DHookCallback_CTFPlayer_CalculateMaxSpeed);
 	dhook_CTFPlayer_AddToSpyKnife.Enable(Hook_Pre, DHookCallback_CTFPlayer_AddToSpyKnife);
 	dhook_CTFAmmoPack_PackTouch.Enable(Hook_Pre, DHookCallback_CTFAmmoPack_PackTouch);
-	dhook_CTFProjectile_Arrow_BuildingHealingArrow.Enable(Hook_Pre, PreHealingBoltImpact);
-	dhook_CTFProjectile_Arrow_BuildingHealingArrow.Enable(Hook_Post, PostHealingBoltImpact);
+	dhook_CTFProjectile_Arrow_BuildingHealingArrow.Enable(Hook_Pre, DHookCallback_CTFProjectile_Arrow_BuildingHealingArrow_Pre);
+	dhook_CTFProjectile_Arrow_BuildingHealingArrow.Enable(Hook_Post, DHookCallback_CTFProjectile_Arrow_BuildingHealingArrow_Post);
 	dhook_CTFPlayer_RegenThink.Enable(Hook_Pre, DHookCallback_CTFPlayer_RegenThink_Pre);
 	dhook_CTFPlayer_RegenThink.Enable(Hook_Post, DHookCallback_CTFPlayer_RegenThink_Post);
-	dhook_CTFPlayerShared_SetRageMeter.Enable(Hook_Pre, ModifyRageMeter);
-	dhook_CTFPlayerShared_SetRageMeter.Enable(Hook_Post, ModifyRageMeter);
+	dhook_CTFPlayerShared_SetRageMeter.Enable(Hook_Pre, DHookCallback_CTFPlayerShared_SetRageMeter);
+	dhook_CTFPlayerShared_SetRageMeter.Enable(Hook_Post, DHookCallback_CTFPlayerShared_SetRageMeter);
 
 	for (idx = 1; idx <= MaxClients; idx++) {
 		if (IsClientConnected(idx)) OnClientConnected(idx);
@@ -6198,7 +6198,7 @@ MRESReturn DHookCallback_CTFAmmoPack_PackTouch(int entity, DHookParam parameters
 	return MRES_Ignored;
 }
 
-MRESReturn PreHealingBoltImpact(int arrowEntity, DHookParam parameters) {
+MRESReturn DHookCallback_CTFProjectile_Arrow_BuildingHealingArrow_Pre(int arrowEntity, DHookParam parameters) {
 	MRESReturn returnValue = MRES_Ignored;
 	int engineerIndex = GetEntityOwner(arrowEntity); // Get attacking entity.
 
@@ -6236,7 +6236,7 @@ MRESReturn PreHealingBoltImpact(int arrowEntity, DHookParam parameters) {
 	return returnValue;
 }
 
-MRESReturn PostHealingBoltImpact(int arrowEntity, DHookParam parameters) {
+MRESReturn DHookCallback_CTFProjectile_Arrow_BuildingHealingArrow_Post(int arrowEntity, DHookParam parameters) {
 	MRESReturn returnValue = MRES_Ignored;
 	int buildingIndex = parameters.Get(1);
 	int engineerIndex = GetEntityOwner(arrowEntity);
@@ -6371,7 +6371,7 @@ MRESReturn DHookCallback_CTFPlayer_RegenThink_Post(int client)
     return MRES_Ignored;
 }
 
-MRESReturn ModifyRageMeter(Address thisPointer, DHookParam parameters)
+MRESReturn DHookCallback_CTFPlayerShared_SetRageMeter(Address thisPointer, DHookParam parameters)
 {
 	// Imported from NotnHeavy's plugin
     int client = GetEntityFromAddress(Dereference(thisPointer + CTFPlayerShared_m_pOuter));

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -123,6 +123,7 @@ public Plugin myinfo = {
 #define TF_DEATH_FEIGN_DEATH 0x20
 #define TF_FLAGTYPE_PLAYER_DESTRUCTION 6
 #define SHIELD_NORMAL_VALUE 0.33
+#define LOADOUT_POSITION_SECONDARY 1
 
 enum
 {
@@ -1456,6 +1457,31 @@ public void OnGameFrame() {
 							}
 						}
 					}
+
+					{
+						// razorback no recharge
+
+						if (
+							ItemIsEnabled(Wep_Razorback) &&
+							player_weapons[idx][Wep_Razorback]
+						) {
+							for (int i = 0; i < TF2Util_GetPlayerWearableCount(idx); i++)
+							{
+								weapon = TF2Util_GetPlayerWearable(idx, i);
+
+								if (weapon > 0) {
+
+									if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 57) {
+	
+										timer = GetEntPropFloat(idx, Prop_Send, "m_flItemChargeMeter", LOADOUT_POSITION_SECONDARY);
+										if (timer < 0.1) {
+											RemoveEntity(weapon);
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 
 				if (TF2_GetPlayerClass(idx) == TFClass_Spy) {
@@ -2627,9 +2653,8 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			sword_reverted = true;
 		}}
 		case 57: { if (ItemIsEnabled(Wep_Razorback)) {
-			TF2Items_SetNumAttributes(itemNew, 2);
-			TF2Items_SetAttribute(itemNew, 0, 800, 1.0); //overheal penalty
-			TF2Items_SetAttribute(itemNew, 1, 874, 10000.0); //shield regen time. big number so it never respawns
+			TF2Items_SetNumAttributes(itemNew, 1);
+			TF2Items_SetAttribute(itemNew, 0, 800, 1.0); // 0% maximum overheal on wearer
 		}}
 		case 411: { if (ItemIsEnabled(Wep_QuickFix)) {
 			TF2Items_SetNumAttributes(itemNew, 1);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1407,7 +1407,7 @@ public void OnGameFrame() {
 						// sydney sleeper headshots don't reduce jarate cooldown
 
 						if (
-							ItemIsEnabled(Wep_SydneySleeper) &&
+							GetItemVariant(Wep_SydneySleeper) == 0 &&
 							player_weapons[idx][Wep_SydneySleeper]
 						) {
 							weapon = GetPlayerWeaponSlot(idx, TFWeaponSlot_Secondary);

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1419,12 +1419,7 @@ public void OnGameFrame() {
 								if (StrEqual(class, "tf_weapon_jar")) {
 									timer = GetEntPropFloat(weapon, Prop_Send, "m_flEffectBarRegenTime");
 
-									if (
-										timer > 0.1 &&
-										players[idx].secondary_regen_time > 0.1 &&
-										(players[idx].secondary_regen_time - timer) > 0.99 &&
-										(players[idx].secondary_regen_time - timer) < 1.01
-									) {
+									if (players[idx].headshot_frame + 1 == GetGameTickCount()) {
 										timer = players[idx].secondary_regen_time;
 										SetEntPropFloat(weapon, Prop_Send, "m_flEffectBarRegenTime", timer);
 									}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1469,7 +1469,7 @@ public void OnGameFrame() {
 									if (GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 57) {
 	
 										timer = GetEntPropFloat(idx, Prop_Send, "m_flItemChargeMeter", LOADOUT_POSITION_SECONDARY);
-										if (timer < 0.1) {
+										if (timer < 1.0) {
 											RemoveEntity(weapon);
 										}
 									}
@@ -2220,10 +2220,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			}
 		}}
 		case 237: { if (ItemIsEnabled(Wep_RocketJumper)) {
-			switch (GetItemVariant(Wep_RocketJumper)) {
-				case 0: { // RocketJmp_Pre2013
-					TF2Items_SetNumAttributes(itemNew, 0);
-				}				
+			switch (GetItemVariant(Wep_RocketJumper)) {				
 				case 1: { // RocketJmp_Release
 					TF2Items_SetNumAttributes(itemNew, 2);
 					TF2Items_SetAttribute(itemNew, 0, 400, 0.0); // cannot_pick_up_intelligence

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -6265,7 +6265,10 @@ MRESReturn DHookCallback_CObjectDispenser_DispenseAmmo(int entity, DHookReturn r
 		client > 0 &&
 		client <= MaxClients
 	) {
-		if (TF2Attrib_HookValueInt(0, "ammo_becomes_health", client) == 1) {
+		if (
+			ItemIsEnabled(Wep_Persian) &&
+			TF2Attrib_HookValueInt(0, "ammo_becomes_health", client) == 1
+		) {
 			// Prevent ammo pick-up from Dispensers with Persian Persuader equipped.
 			returnValue.Value = false;
 			return MRES_Supercede;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3130,7 +3130,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 							ItemIsEnabled(Wep_Powerjack) &&
 							GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 214
 						) {
-							// Save kill tick for later use
+							// Save kill tick for applying overheal on next tick
 							players[attacker].powerjack_kill_tick = GetGameTickCount();
 						}
 						if (


### PR DESCRIPTION
### Summary of changes
powerjack: put heal on kill amount in attribute and use tf2utils for healing
release cleaner's carbine: use crikey meter for visualizing remaining buff duration
use tf2utils in various places
phlog: fix rage gain and do away with rage dhook
sydney sleeper: code cleanup and proper crit rampup for release sleeper
use cvar for base jumper redeploy and remove involved logic
pre-bluemoon sydney sleeper jarate icon when scoped and lagcomped teammate extinguish
different methodology for reverted razorback
fix being able to pick up ammo from dispensers with persuader equipped

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on bots

### Other Info
fixes #97 