### PR TITLE
(Revert) Pre-BM flamethrower

### DIFF
--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -7,6 +7,7 @@ sm_reverts__pre_toughbreak_switch 0
 sm_reverts__show_moonshot 0
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 1

--- a/cfg/reverts_disable_all.cfg
+++ b/cfg/reverts_disable_all.cfg
@@ -7,6 +7,7 @@ sm_reverts__pre_toughbreak_switch 0
 sm_reverts__show_moonshot 0
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 0
+sm_reverts__item_flamethrower 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 0

--- a/cfg/reverts_enable_all.cfg
+++ b/cfg/reverts_enable_all.cfg
@@ -7,6 +7,7 @@ sm_reverts__pre_toughbreak_switch 1
 sm_reverts__show_moonshot 1
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1

--- a/cfg/reverts_high.cfg
+++ b/cfg/reverts_high.cfg
@@ -4,6 +4,7 @@
 
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -6,6 +6,7 @@
 
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 0
 sm_reverts__item_ambassador 1

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -6,6 +6,7 @@
 
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -3,6 +3,7 @@
 
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -13,6 +13,8 @@ sm_reverts__item_airblast 1
 // note: airblast revert is not 100% accurate due to different hitboxes
 sm_reverts__item_airstrike 0
 // airstrike lacks pre-GM version
+sm_reverts__item_flamethrower 1
+// closest revert for flamethrowers available
 sm_reverts__item_miniramp 0
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1

--- a/gamedata/memorypatch_reverts.txt
+++ b/gamedata/memorypatch_reverts.txt
@@ -201,7 +201,7 @@
 				}
 
 				// ================================================
-				//  (TEST ATTEMPT) Revert flamethrower damage to Pre-Bluemoon.
+				//  Revert flamethrower damage and mechanics to Pre-Bluemoon/Jungle Inferno.
  
 				"CTFFlameManager::GetFlameDamageScale_SkipDensityClampingFlameDamage"
 				{
@@ -210,14 +210,14 @@
 					{
 						"offset"    "239"
 						"verify" "\x0F\x84\x2A\x2A\x2A\x2A"
-						"patch"  "\xE9\x93\x00\x00\x00\x90"
+						"patch"  "\xE9\x93\x00\x00\x00\x90" // JMP 147 bytes forward, NOP
  
 					}
 					"windows"
 					{
 						"offset"    "349"
 						"verify" "\x0F\x84\x2A\x2A\x2A\x2A"
-						"patch"  "\xE9\x88\x00\x00\x00\x90"
+						"patch"  "\xE9\x88\x00\x00\x00\x90" // JMP 136 bytes forward, NOP
 					}
 				}
  
@@ -228,14 +228,14 @@
 					{
 						"offset"    "254"
 						"verify"    "\x74\x2A"
-						"patch"     "\xEB\x5A"
+						"patch"     "\xEB\x5A" // JMP SHORT +0x5A, jump 90 bytes forward from the instruction following it
  
 					}
 					"windows"
 					{
 						"offset"    "270"
 						"verify"    "\x74\x2A" // JZ rel8 (wildcarded offset)
-						"patch"     "\xEB\x58" 
+						"patch"     "\xEB\x58" // JMP SHORT +0x58, jump 88 bytes forward from the instruction immediately following it
 					}
 				}
 

--- a/gamedata/memorypatch_reverts.txt
+++ b/gamedata/memorypatch_reverts.txt
@@ -96,6 +96,18 @@
 				// this is weird, blame makesig.idc for this
 				"windows" "\x57\x8B\xF9\x8B\x0D\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x84\xC0\x0F\x85\x2A\x2A\x2A\x2A"
 			}
+			"CTFFlameManager::GetFlameDamageScale"
+			{
+				"library"	"server"
+				"linux"		"@_ZNK15CTFFlameManager19GetFlameDamageScaleEPK10tf_point_tP9CTFPlayer"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x8B\x15\x2A\x2A\x2A\x2A\x57"
+			}
+			"CTFFlameManager::OnCollide"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFFlameManager9OnCollideEP11CBaseEntityi"
+				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x2A\x89\x6C\x24\x2A\x8B\xEC\x81\xEC\x78\x01\x00\x00"
+			}
 		}
 
 		"MemPatches"
@@ -185,6 +197,45 @@
 						"offset"    "1676"
 						"verify"    "\x74\x2A" // JZ rel8 (wildcarded offset)
 						"patch"     "\x90\x90" // 2x NOP
+					}
+				}
+
+				// ================================================
+				//  (TEST ATTEMPT) Revert flamethrower damage to Pre-Bluemoon.
+ 
+				"CTFFlameManager::GetFlameDamageScale_SkipDensityClampingFlameDamage"
+				{
+					"signature" "CTFFlameManager::GetFlameDamageScale"
+					"linux"
+					{
+						"offset"    "239"
+						"verify" "\x0F\x84\x2A\x2A\x2A\x2A"
+						"patch"  "\xE9\x93\x00\x00\x00\x90"
+ 
+					}
+					"windows"
+					{
+						"offset"    "349"
+						"verify" "\x0F\x84\x2A\x2A\x2A\x2A"
+						"patch"  "\xE9\x88\x00\x00\x00\x90"
+					}
+				}
+ 
+				"CTFFlameManager::OnCollide_SkipDensityClampingFlameDamage"
+				{
+					"signature" "CTFFlameManager::OnCollide"
+					"linux"
+					{
+						"offset"    "254"
+						"verify"    "\x74\x2A"
+						"patch"     "\xEB\x5A"
+ 
+					}
+					"windows"
+					{
+						"offset"    "270"
+						"verify"    "\x74\x2A" // JZ rel8 (wildcarded offset)
+						"patch"     "\xEB\x58" 
 					}
 				}
 

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -253,6 +253,8 @@ Address AddressOf_g_flNewDiscilplinaryAllySpeedBuffTimer;
 #endif
 
 MemoryPatch patch_RevertDragonsFury_CenterHitForBonusDmg;
+MemoryPatch patch_RevertFlamethrowers_Density_DmgScale;
+MemoryPatch patch_RevertFlamethrowers_Density_OnCollide;
 MemoryPatch patch_RevertMiniguns_RampupNerf_Dmg;
 MemoryPatch patch_RevertMiniguns_RampupNerf_Spread;
 MemoryPatch patch_RevertWrangler_WrenchRepairNerf;
@@ -320,6 +322,7 @@ enum
 	//Generic class features
 	Feat_Airblast,
 #if defined MEMORY_PATCHES
+	Feat_Flamethrower, // All Flamethrowers
 	Feat_Minigun, // All Miniguns
 #endif
 	Feat_Sword, // All Swords	
@@ -471,6 +474,7 @@ public void OnPluginStart() {
 	ItemDefine("airblast", "Airblast_PreJI", CLASSFLAG_PYRO, Feat_Airblast);
 	ItemDefine("airstrike", "Airstrike_PreTB", CLASSFLAG_SOLDIER, Wep_Airstrike);
 #if defined MEMORY_PATCHES
+	ItemDefine("flamethrower", "Flamethrower_PreBM", CLASSFLAG_PYRO, Feat_Flamethrower, true);
 	ItemDefine("miniramp", "Minigun_ramp_PreLW", CLASSFLAG_HEAVY, Feat_Minigun, true);
 #endif
 	ItemDefine("swords", "Swords_PreTB", CLASSFLAG_DEMOMAN, Feat_Sword);
@@ -743,6 +747,12 @@ public void OnPluginStart() {
 			MemoryPatch.CreateFromConf(conf,
 			"CTFProjectile_BallOfFire::Burn_SkipCenterHitRequirement");
 
+		patch_RevertFlamethrowers_Density_DmgScale =
+			MemoryPatch.CreateFromConf(conf,
+			"CTFFlameManager::GetFlameDamageScale_SkipDensityClampingFlameDamage");
+		patch_RevertFlamethrowers_Density_OnCollide =
+			MemoryPatch.CreateFromConf(conf,
+			"CTFFlameManager::OnCollide_SkipDensityClampingFlameDamage");
 		patch_RevertMiniguns_RampupNerf_Dmg =
 			MemoryPatch.CreateFromConf(conf,
 			"CTFMinigun::GetProjectileDamage_JumpOver1SecondCheck");
@@ -785,6 +795,8 @@ public void OnPluginStart() {
 
 		if (!ValidateAndNullCheck(patch_RevertDisciplinaryAction)) SetFailState("Failed to create patch_RevertDisciplinaryAction");
 		if (!ValidateAndNullCheck(patch_RevertDragonsFury_CenterHitForBonusDmg)) SetFailState("Failed to create patch_RevertDragonsFury_CenterHitForBonusDmg");
+		if (!ValidateAndNullCheck(patch_RevertFlamethrowers_Density_DmgScale)) SetFailState("Failed to create patch_RevertFlamethrowers_Density_DmgScale");
+		if (!ValidateAndNullCheck(patch_RevertFlamethrowers_Density_OnCollide)) SetFailState("Failed to create patch_RevertFlamethrowers_Density_OnCollide");
 		if (!ValidateAndNullCheck(patch_RevertMiniguns_RampupNerf_Dmg)) SetFailState("Failed to create patch_RevertMiniguns_RampupNerf_Dmg");
 		if (!ValidateAndNullCheck(patch_RevertMiniguns_RampupNerf_Spread)) SetFailState("Failed to create patch_RevertMiniguns_RampupNerf_Spread");
 		if (!ValidateAndNullCheck(patch_RevertWrangler_WrenchRepairNerf)) SetFailState("Failed to create patch_RevertWrangler_WrenchRepairNerf");
@@ -890,6 +902,7 @@ public void OnConfigsExecuted() {
 #if defined MEMORY_PATCHES
 	ToggleMemoryPatchReverts(ItemIsEnabled(Wep_Disciplinary),Wep_Disciplinary);
 	ToggleMemoryPatchReverts(ItemIsEnabled(Wep_DragonFury),Wep_DragonFury);
+	ToggleMemoryPatchReverts(ItemIsEnabled(Feat_Flamethrower),Feat_Flamethrower);
 	ToggleMemoryPatchReverts(ItemIsEnabled(Feat_Minigun),Feat_Minigun);
 	ToggleMemoryPatchReverts(ItemIsEnabled(Wep_Wrangler),Wep_Wrangler);
 	ToggleMemoryPatchReverts(ItemIsEnabled(Wep_CozyCamper),Wep_CozyCamper);
@@ -945,6 +958,15 @@ void ToggleMemoryPatchReverts(bool enable, int wep_enum) {
 				patch_RevertDragonsFury_CenterHitForBonusDmg.Enable();
 			} else {
 				patch_RevertDragonsFury_CenterHitForBonusDmg.Disable();
+			}
+		}
+		case Feat_Flamethrower: {
+			if (enable) {
+				patch_RevertFlamethrowers_Density_DmgScale.Enable();
+				patch_RevertFlamethrowers_Density_OnCollide.Enable();
+			} else {
+				patch_RevertFlamethrowers_Density_DmgScale.Disable();
+				patch_RevertFlamethrowers_Density_OnCollide.Disable();
 			}
 		}
 		case Feat_Minigun: {
@@ -3146,6 +3168,9 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 					}
 
 #if defined MEMORY_PATCHES
+					else if (StrEqual(class, "tf_weapon_flamethrower")) {
+						player_weapons[client][Feat_Flamethrower] = true;
+					}
 					else if (StrEqual(class, "tf_weapon_minigun")) {
 						player_weapons[client][Feat_Minigun] = true;
 					}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -3168,7 +3168,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 					}
 
 #if defined MEMORY_PATCHES
-					else if (StrEqual(class, "tf_weapon_flamethrower")) {
+					if (StrEqual(class, "tf_weapon_flamethrower")) {
 						player_weapons[client][Feat_Flamethrower] = true;
 					}
 					else if (StrEqual(class, "tf_weapon_minigun")) {

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -130,6 +130,10 @@
 	{
 		"en"	"Air Strike"
 	}
+	"flamethrower"
+	{
+		"en"	"All Flamethrowers"
+	}
 	"miniramp"
 	{
 		"en"	"All Miniguns"
@@ -471,6 +475,10 @@
 	"Airstrike_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, no extra blast radius penalty when blast jumping"
+	}
+	"Flamethrower_PreBM"
+	{
+		"en"	"Reverted to pre-bluemoon, no flame dmg ramp up based on density of flame encountered, +50%% initial flame dmg"
 	}
 	"Minigun_ramp_PreLW"
 	{


### PR DESCRIPTION
### Summary of changes
Reverts Flamethrower's flames to pre-blue moon
Credits to VerdiusArcana @BringBackQuickPlay 
Mempatch revert

[March 28, 2018 Patch 1](https://wiki.teamfortress.com/wiki/March_28,_2018_Patch)

    Flame damage per second now ramps up based on density of flame encountered, up to 200%.
    Initial flame damage per second reduced by 50%, resulting in the max damage being unchanged.
    Fixed Flame Thrower particles sometimes failing to draw on the client.
    Fixed Flame Thrower flames not colliding with tf_generic_bomb entities.

### Testing Attestation
- [x] - This change has been tested on Windows
- [x] - This change has been tested on Linux
- [x] - This change has been compared with an actual pre-Blue Moon build of TF2 / has been thoroughly researched to almost be the same as the pre-Blue Moon Flamethrowers

### Description of testing
Mouse1 on enemy Pyro Bot at a pre-determined distance, compare dmg numbers and time to kill with vanilla and with revert, with focus fire and with swinging/flailing fire
Swinging the flamethrower should not reduce the flame damage by half
Basically you should see the flame particles deal 13 dmg flat at close range and 6.5 flat at farther ranges for the revert

```
POINT BLANK TIME TO KILL TIMES
Revert JI Focus Time to kill: 2.25 s
	dmg: 311
	~138 DPS
Modern Focus Time to kill: 3.10 s
	dmg: 307
	~99 DPS
Actual JI TF2 Build Focus Time to kill: 2.20 s
	dmg: 311
	~141 DPS

Flailing fire average damage numbers
	Modern Flamethrower: 6.55
	Revert JI Flamethrower: 9.97
	Actual JI Flamethrower: 9.55
		Dmg Diff between JI revert and JI actual: 0.42 (within error, less than 1)

Conclusion: JI Revert is accurate to actual JI Flamethrower.
```

### Other Info
to finish testing with video proof
Someone else should test out damage numbers with an actual tf2 build from jungle inferno era. [I have confirmed that this revert is historically accurate to JI flamethrower now](https://github.com/rsedxcftvgyhbujnkiqwe/castaway-plugins/pull/292#issuecomment-3341291241).

> VerdiusArcana: More specifically, the patch causes this if statement to be skipped:https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/tf/tf_flame.cpp#L531
> And this if statement is also skipped:https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/tf/tf_flame.cpp#L685


references:
Post Blue Moon Flamethrower demonstration: https://www.youtube.com/watch?v=JqaI5LhNalk
Jungle Inferno Flamethrower demonstration: https://www.youtube.com/watch?v=aIIgr_qt8mw
JI flamethrower Wiki page: https://wiki.teamfortress.com/w/index.php?title=Flame_Thrower&oldid=2294742
