### PR TITLE
add can't gain ammo from dispensers to persuader info

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -810,7 +810,7 @@
 	}
 	"Persuader_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, picks up ammo as health, +100%% charge recharge rate, no max ammo penalty"
+		"en"	"Reverted to pre-toughbreak, picks up ammo as health, +100%% charge recharge rate, no max ammo penalty, cannot gain ammo from dispensers and carts"
 	}
 	"Phlog_Pyro"
 	{


### PR DESCRIPTION
cannot gain ammo from dispensers and carts

### Summary of changes
[A quick summary of changes from this PR]

### Testing Attestation
- [ ] - This change has been tested
- [X] - This change has not been tested, reasoning below

### Description of testing
desc change

### Other Info
done to reflect the new persian persuader fix #291 
