### PR TITLE
Iron bomber reverts

### DIFF
--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -52,6 +52,7 @@ sm_reverts__item_glovesru 2
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 0
+sm_reverts__item_ironbomber 0
 sm_reverts__item_jag 0
 sm_reverts__item_liberty 1
 sm_reverts__item_lochload 1

--- a/cfg/reverts_disable_all.cfg
+++ b/cfg/reverts_disable_all.cfg
@@ -52,6 +52,7 @@ sm_reverts__item_glovesru 0
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 0
 sm_reverts__item_hibernate 0
+sm_reverts__item_ironbomber 0
 sm_reverts__item_jag 0
 sm_reverts__item_liberty 0
 sm_reverts__item_lochload 0

--- a/cfg/reverts_enable_all.cfg
+++ b/cfg/reverts_enable_all.cfg
@@ -52,6 +52,7 @@ sm_reverts__item_glovesru 1
 sm_reverts__item_gunboats 1
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 1
+sm_reverts__item_ironbomber 1
 sm_reverts__item_jag 1
 sm_reverts__item_liberty 1
 sm_reverts__item_lochload 1

--- a/cfg/reverts_high.cfg
+++ b/cfg/reverts_high.cfg
@@ -50,6 +50,7 @@ sm_reverts__item_glovesru 1
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 1
+sm_reverts__item_ironbomber 1
 sm_reverts__item_jag 1
 sm_reverts__item_liberty 1
 sm_reverts__item_lochload 1

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -51,6 +51,7 @@ sm_reverts__item_glovesru 2
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 0
 sm_reverts__item_hibernate 0
+sm_reverts__item_ironbomber 1
 sm_reverts__item_jag 0
 sm_reverts__item_liberty 0
 sm_reverts__item_lochload 0

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -51,6 +51,7 @@ sm_reverts__item_glovesru 1
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 0
 sm_reverts__item_hibernate 1
+sm_reverts__item_ironbomber 1
 sm_reverts__item_jag 1
 sm_reverts__item_liberty 0
 sm_reverts__item_lochload 1

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -49,6 +49,7 @@ sm_reverts__item_glovesru 3
 sm_reverts__item_gunboats 1
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 1
+sm_reverts__item_ironbomber 1
 sm_reverts__item_jag 1
 sm_reverts__item_liberty 1
 sm_reverts__item_lochload 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -67,6 +67,8 @@ sm_reverts__item_glovesru 1
 sm_reverts__item_gunboats 0
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 0
+sm_reverts__item_ironbomber 1
+// closest version for the iron bomber
 sm_reverts__item_jag 2
 sm_reverts__item_liberty 0
 // liberty lacks pre-GM version (no +25 clip size bonus)

--- a/gamedata/memorypatch_reverts.txt
+++ b/gamedata/memorypatch_reverts.txt
@@ -118,7 +118,13 @@
 				"library"	"server"
 				"linux"		"@_ZN15CTFFlameManager9OnCollideEP11CBaseEntityi"
 				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x2A\x89\x6C\x24\x2A\x8B\xEC\x81\xEC\x78\x01\x00\x00"
-      }      
+			}
+			"CTFWeaponBaseGun::FirePipeBomb"
+			{
+				"library"	"server"
+				"linux"		"@_ZN16CTFWeaponBaseGun12FirePipeBombEP9CTFPlayeri"
+				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x2A\x89\x6C\x24\x2A\x8B\xEC\x81\xEC\x68\x01\x00\x00\x56\x8B\xF1"
+			}
 		}
 
 		"MemPatches"
@@ -255,6 +261,29 @@
 				// ╚══════════════════════════════════════════════╝
 
 				//  Demoman related MemoryPatches go here.
+
+				// ================================================
+				//  Iron Bomber - Pre-July 7, 2022 patch
+				//  Reverts Iron Bomber hitbox back when it used to have a bigger hitbox
+				//	Normal pipe grenade hitbox size is 4x4x4. 
+				//	Pre-patch Iron Bomber pipe size was 8.75 x 8.75 x 7.71424 according to https://github.com/ldesgoui/tf2-comp-fixes
+
+				"CTFWeaponBaseGun::FirePipeBomb_IronBomberHitboxRevert"
+				{
+					"signature"	"CTFWeaponBaseGun::FirePipeBomb"
+					"linux"
+					{
+						"offset"	"2092"
+						"verify"	"\xE8\x0F\x2C\x2A\x2A" // CALL, x2A wildcard twice
+						"patch"		"\x90\x90\x90\x90\x90" // NOP 5x
+					}
+					"windows"
+					{
+						"offset"	"1383"
+						"verify"	"\xE8\xC4\x35\x2A\x2A" // CALL, x2A wildcard twice
+						"patch"		"\x90\x90\x90\x90\x90" // NOP 5x
+					}
+				}
 
 				// ╔══════════════════════════════════════════════╗
 				// ║                    Heavy                     ║

--- a/gamedata/memorypatch_reverts.txt
+++ b/gamedata/memorypatch_reverts.txt
@@ -267,6 +267,8 @@
 				//  Reverts Iron Bomber hitbox back when it used to have a bigger hitbox
 				//	Normal pipe grenade hitbox size is 4x4x4. 
 				//	Pre-patch Iron Bomber pipe size was 8.75 x 8.75 x 7.71424 according to https://github.com/ldesgoui/tf2-comp-fixes
+				//	This prevents the UTIL_SetSize function from being called. UTIL_SetSize is what adjusts the hitbox back to 4x4x4.
+				//	Function can be found via the DevMsg string in a decompiler.
 
 				"CTFWeaponBaseGun::FirePipeBomb_IronBomberHitboxRevert"
 				{

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -394,6 +394,7 @@ enum
 	Wep_GRU,
 	Wep_Gunboats,
 	Wep_Zatoichi, // Half-Zatoichi
+	Wep_IronBomber,
 	Wep_Jag,
 	Wep_LibertyLauncher,
 	Wep_LochLoad,
@@ -569,6 +570,7 @@ public void OnPluginStart() {
 	ItemDefine("gunboats", "Gunboats_Release", CLASSFLAG_SOLDIER, Wep_Gunboats);
 	ItemDefine("zatoichi", "Zatoichi_PreTB", CLASSFLAG_SOLDIER | CLASSFLAG_DEMOMAN, Wep_Zatoichi);
 	ItemDefine("hibernate", "Hibernate_Release", CLASSFLAG_HEAVY | ITEMFLAG_DISABLED, Set_Hibernate);
+	ItemDefine("ironbomber", "IronBomber_Pre2022", CLASSFLAG_DEMOMAN, Wep_IronBomber);
 	ItemDefine("jag", "Jag_PreTB", CLASSFLAG_ENGINEER, Wep_Jag);
 	ItemVariant(Wep_Jag, "Jag_PreGM");  
 	ItemDefine("liberty", "Liberty_Release", CLASSFLAG_SOLDIER, Wep_LibertyLauncher);
@@ -3298,6 +3300,7 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 						case 416: player_weapons[client][Wep_MarketGardener] = true;
 						case 239, 1084, 1100: player_weapons[client][Wep_GRU] = true;
 						case 812, 833: player_weapons[client][Wep_Cleaver] = true;
+						case 1151: player_weapons[client][Wep_IronBomber] = true;
 						case 329: player_weapons[client][Wep_Jag] = true;
 						case 414: player_weapons[client][Wep_LibertyLauncher] = true;
 						case 308: player_weapons[client][Wep_LochLoad] = true;

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -310,6 +310,10 @@
 	{
 		"en"	"Hibernating Bear"
 	}
+	"ironbomber"
+	{
+		"en"	"Iron Bomber"
+	}
 	"jag"
 	{
 		"en"	"Jag"
@@ -496,10 +500,10 @@
 	{
 		"en"	"Reverted to pre-August 27, 2014; can jump immediately after firing a scoped shot (scope jumping)"
 	}
-  "Stickybomb_PreLW"
+	"Stickybomb_PreLW"
 	{
 		"en"	"Reverted to pre-love&war, +9%% base blast radius; air-detonated stickies have full blast radius"
-  }
+	}
 	"Swords_PreTB"
 	{
 		"en"	"Reverted to pre-toughbreak, no holster and deploy switch speed penalties"
@@ -779,6 +783,10 @@
 	"Hibernate_Release"
 	{
 		"en"	"Restored release item set bonus, +5%% crit resist. Equip the Brass Beast, Buffalo Steak Sandvich and Warrior's Spirit to gain the bonus, the hat is not required"
+	}
+	"IronBomber_Pre2022"
+	{
+		"en"	"Reverted to pre-July 7, 2022; ~2x larger grenade hitbox"
 	}
 	"Jag_PreTB"
 	{


### PR DESCRIPTION
### Summary of changes

Iron Bomber - Reverted to pre-July 7, 2022; ~2x larger grenade hitbox

Memory Patch for Iron Bomber, increase hitbox size to 8.7x8.7x7.7, which is basically about 2x larger (by area or ~8x increase by volume)
This is done by preventing the[ UTIL_SetSize function](https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/tf/tf_weaponbase_gun.cpp#L723C4-L723C88) from being called which corrects it back to 4x4x4

https://wiki.teamfortress.com/wiki/July_7,_2022_Patch
```
[July 7, 2022 Patch](https://wiki.teamfortress.com/wiki/July_7,_2022_Patch)
    Fixed the Iron Bomber's projectile collision size not matching other projectile collision sizes.
```
### Testing Attestation
- [x] - This change has been tested on Windows
- [ ] - This change has been tested on Linux

### Description of testing
itemtest with bots
```
	bot_teleport bot01 1695.853516 -2320.800537 -116.968681 0 90 0
	// spawn a dispenser inside the bot
	ent_create obj_dispenser teamnum 2
	setpos 1675.685547 -2272.769287 -123.968681;setang 10 -90.000000 0.000000
	bot_command addcond 51; bot_command addcond 130
	addcond 51; addcond 130
	
	how to see bounding box:
	host_timescale 0.5
	// so you can react to it just in time
	// fire the grenade
	// look at the grenade
	// quickly type 
	cl_ent_bbox
	// cl_ent_bbox in your CLIENT console. it has to be done via client console.
```

### Other Info
The idea for patching UTIL_SetSize in [CTFWeaponBaseGun::FirePipeBomb function](https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/tf/tf_weaponbase_gun.cpp#L647) was found from the override pipe size plugin used by [tf2 comp fixes](https://github.com/ldesgoui/tf2-comp-fixes), which used a hook to adjust grenade hitboxes to 4x4x4. The [DevMsg ](https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/tf/tf_weaponbase_gun.cpp#L661) of CTFWeaponBaseGun::FirePipeBomb was then used to find the function in decompiled code.
