### PR TITLE
(Reverts) fix (mini-)crit resist for reverted brass beast and natascha

### DIFF
--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -8,6 +8,7 @@ sm_reverts__show_moonshot 0
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
 sm_reverts__item_flamethrower 0
+sm_reverts__item_grenade 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_sniperrifles 0
 sm_reverts__item_stickybomb 0

--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -8,6 +8,8 @@ sm_reverts__enable_shortstop_shove 1
 sm_reverts__show_moonshot 1
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
+sm_reverts__item_flamethrower 1
+sm_reverts__item_grenade 0
 sm_reverts__item_miniramp 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
@@ -59,7 +61,7 @@ sm_reverts__item_gardener 1
 sm_reverts__item_natascha 1
 sm_reverts__item_panic 1
 sm_reverts__item_persuader 1
-sm_reverts__item_phlog 0
+sm_reverts__item_phlog 1
 sm_reverts__item_pomson 1
 sm_reverts__item_powerjack 1
 sm_reverts__item_pocket 1
@@ -73,7 +75,7 @@ sm_reverts__item_rocketjmp 1
 sm_reverts__item_saharan 2
 sm_reverts__item_sandman 1
 sm_reverts__item_scottish 0
-sm_reverts__item_circuit 2
+sm_reverts__item_circuit 0
 sm_reverts__item_shortstop 1
 sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1

--- a/cfg/reverts_disable_all.cfg
+++ b/cfg/reverts_disable_all.cfg
@@ -8,6 +8,7 @@ sm_reverts__show_moonshot 0
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 0
 sm_reverts__item_flamethrower 0
+sm_reverts__item_grenade 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_sniperrifles 0
 sm_reverts__item_stickybomb 0

--- a/cfg/reverts_enable_all.cfg
+++ b/cfg/reverts_enable_all.cfg
@@ -8,6 +8,7 @@ sm_reverts__show_moonshot 1
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
 sm_reverts__item_flamethrower 1
+sm_reverts__item_grenade 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_sniperrifles 1
 sm_reverts__item_stickybomb 1

--- a/cfg/reverts_enable_itemsets.cfg
+++ b/cfg/reverts_enable_itemsets.cfg
@@ -22,6 +22,7 @@ sm_reverts__item_powerjack 3
 
 // DEMOMAN - The Expert's Ordnance
 // Loch-n-Load is reverted to pre-Smissmas 2014 for historical accuracy
+sm_reverts__item_grenade 1
 sm_reverts__item_expert 1
 sm_reverts__item_lochload 2
 sm_reverts__item_caber 1
@@ -60,5 +61,5 @@ sm_reverts__item_bushwacka 1
 
 // SPY - The Saharan Spy
 sm_reverts__item_saharan 1
-// TO DO: add pre-2013 L'Etranger revert
+// this variant removes the extended L'Etranger cloak duration when bonus is active
 sm_reverts__item_eternal 1

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -7,6 +7,7 @@
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
 sm_reverts__item_flamethrower 0
+sm_reverts__item_grenade 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_sniperrifles 0
 sm_reverts__item_stickybomb 0

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -7,6 +7,7 @@
 sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
 sm_reverts__item_flamethrower 1
+sm_reverts__item_grenade 0
 sm_reverts__item_miniramp 1
 sm_reverts__item_sniperrifles 1
 sm_reverts__item_stickybomb 1

--- a/cfg/reverts_mvm.cfg
+++ b/cfg/reverts_mvm.cfg
@@ -1,8 +1,8 @@
-// Weapon reverts preset that 50% of all TF2 players might agree with
-// WARNING: Do not use reverted Dalokohs Bar with unreverted GRU or you will get the old GRU+Dalokohs bar infinite HP exploit again!
-// This is basically the weapon reverts used by Castaway.tf as of July 25, 2025 with more item sets added, equalizer, SR, tomislav, and airblast revert
+// Weapon reverts preset for having the most powerful options in Mann vs Machine
+// Based on my own uninformed opinion
 
-sm_reverts__item_airblast 1
+sm_reverts__pre_toughbreak_switch 0
+sm_reverts__item_airblast 0
 sm_reverts__item_airstrike 1
 sm_reverts__item_flamethrower 1
 sm_reverts__item_grenade 1
@@ -11,7 +11,7 @@ sm_reverts__item_sniperrifles 1
 sm_reverts__item_stickybomb 1
 sm_reverts__item_swords 1
 sm_reverts__item_ambassador 1
-sm_reverts__item_amputator 1
+sm_reverts__item_amputator 0
 sm_reverts__item_atomizer 1
 sm_reverts__item_axtinguish 1
 sm_reverts__item_backburner 1
@@ -25,11 +25,11 @@ sm_reverts__item_brassbeast 1
 sm_reverts__item_bushwacka 1
 sm_reverts__item_buffalosteak 1
 sm_reverts__item_targe 1
-sm_reverts__item_claidheamh 1
-sm_reverts__item_carbine 1
-sm_reverts__item_concheror 1
+sm_reverts__item_claidheamh 0
+sm_reverts__item_carbine 0
+sm_reverts__item_concheror 0
+sm_reverts__item_cowmangler 0
 sm_reverts__item_cozycamper 1
-sm_reverts__item_cowmangler 1
 sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 1
 sm_reverts__item_dalokohsbar 1
@@ -38,18 +38,17 @@ sm_reverts__item_ringer 1
 sm_reverts__item_degreaser 1
 sm_reverts__item_disciplinary 1
 sm_reverts__item_dragonfury 1
-sm_reverts__item_enforcer 1
-sm_reverts__item_equalizer 2
+sm_reverts__item_enforcer 2
+sm_reverts__item_equalizer 3
 sm_reverts__item_eureka 1
-sm_reverts__item_eviction 1
+sm_reverts__item_eviction 2
 sm_reverts__item_expert 1
-sm_reverts__item_fiststeel 1
+sm_reverts__item_fiststeel 3
 sm_reverts__item_guillotine 1
-sm_reverts__item_gasjockey 0
-// gas jockey set disabled due to historical incompatibility with pre-GM powerjack revert
-sm_reverts__item_glovesru 1
-sm_reverts__item_gunboats 0
-sm_reverts__item_gunslinger 1
+sm_reverts__item_gasjockey 1
+sm_reverts__item_glovesru 3
+sm_reverts__item_gunboats 1
+sm_reverts__item_gunslinger 2
 sm_reverts__item_zatoichi 1
 sm_reverts__item_hibernate 1
 sm_reverts__item_ironbomber 1
@@ -59,37 +58,37 @@ sm_reverts__item_lochload 1
 sm_reverts__item_cannon 1
 sm_reverts__item_madmilk 1
 sm_reverts__item_gardener 1
-sm_reverts__item_natascha 1
-sm_reverts__item_panic 1
+sm_reverts__item_natascha 2
+sm_reverts__item_panic 0
 sm_reverts__item_persuader 1
-sm_reverts__item_phlog 2
+sm_reverts__item_phlog 3
 sm_reverts__item_pomson 2
 sm_reverts__item_powerjack 1
 sm_reverts__item_pocket 1
 sm_reverts__item_quickfix 1
-sm_reverts__item_quickiebomb 1
-sm_reverts__item_razorback 1
+sm_reverts__item_quickiebomb 0
+sm_reverts__item_razorback 0
 sm_reverts__item_rescueranger 1
 sm_reverts__item_reserve 1
 sm_reverts__item_bison 1
-sm_reverts__item_rocketjmp 1
+sm_reverts__item_rocketjmp 2
 sm_reverts__item_saharan 2
 sm_reverts__item_sandman 1
-sm_reverts__item_scottish 1
-sm_reverts__item_circuit 2
-sm_reverts__item_shortstop 1
+sm_reverts__item_scottish 0
+sm_reverts__item_circuit 0
+sm_reverts__item_shortstop 3
 sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
-sm_reverts__item_splendid 1
-sm_reverts__item_spycicle 1
+sm_reverts__item_splendid 2
+sm_reverts__item_spycicle 0
 sm_reverts__item_stkjumper 1
 sm_reverts__item_sleeper 1
 sm_reverts__item_turner 1
-sm_reverts__item_tomislav 1
+sm_reverts__item_tomislav 0
 sm_reverts__item_tribalshiv 1
 sm_reverts__item_caber 1
 sm_reverts__item_vitasaw 1
-sm_reverts__item_warrior 1
-sm_reverts__item_wrangler 1
-sm_reverts__item_eternal 1
+sm_reverts__item_warrior 0
+sm_reverts__item_wrangler 2
+sm_reverts__item_eternal 0

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -4,6 +4,7 @@
 sm_reverts__item_airblast 1
 sm_reverts__item_airstrike 1
 sm_reverts__item_flamethrower 1
+sm_reverts__item_grenade 1
 sm_reverts__item_miniramp 1
 sm_reverts__item_sniperrifles 1
 sm_reverts__item_stickybomb 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -16,6 +16,7 @@ sm_reverts__item_airstrike 0
 // airstrike lacks pre-GM version
 sm_reverts__item_flamethrower 1
 // closest revert for flamethrowers available
+sm_reverts__item_grenade 0
 sm_reverts__item_miniramp 0
 sm_reverts__item_sniperrifles 0
 sm_reverts__item_stickybomb 0

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2172,14 +2172,22 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 				GetEntityClassname(weapon, class, sizeof(class));
 
 				if (StrEqual(class, "tf_weapon_minigun")) {
-					// patchless minigun rampup revert
-					TF2Attrib_RemoveByDefIndex(weapon, 36);
-					TF2Attrib_RemoveByDefIndex(weapon, 476);
-					
-					// spunup resist regardless of health
-					TF2Attrib_RemoveByDefIndex(weapon, 63);
-					TF2Attrib_RemoveByDefIndex(weapon, 412);
-					TF2Attrib_RemoveByDefIndex(weapon, 738);
+#if !defined MEMORY_PATCHES
+					if (ItemIsEnabled(Feat_Minigun)) {
+						// patchless minigun rampup revert
+						TF2Attrib_RemoveByDefIndex(weapon, 36);
+						TF2Attrib_RemoveByDefIndex(weapon, 476);
+					}
+#endif
+					if (
+						ItemIsEnabled(Wep_BrassBeast) ||
+						GetItemVariant(Wep_Natascha) == 0
+					) {
+						// spunup resist regardless of health
+						TF2Attrib_RemoveByDefIndex(weapon, 63);
+						TF2Attrib_RemoveByDefIndex(weapon, 412);
+						TF2Attrib_RemoveByDefIndex(weapon, 738);
+					}
 				}
 			}
 		}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2185,7 +2185,7 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 					) {
 						// spunup resist regardless of health
 						TF2Attrib_RemoveByDefIndex(weapon, 63);
-						TF2Attrib_RemoveByDefIndex(weapon, 412);
+						TF2Attrib_RemoveByDefIndex(weapon, 852);
 						TF2Attrib_RemoveByDefIndex(weapon, 738);
 					}
 				}
@@ -2584,14 +2584,14 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 			switch (GetItemVariant(Wep_Eviction)) {
 				case 1: {
 					TF2Items_SetNumAttributes(itemNew, 3);
-					TF2Items_SetAttribute(itemNew, 0, 855, 0.0); // mod maxhealth drain rate
-					TF2Items_SetAttribute(itemNew, 1, 851, 1.00); // +0% faster move speed on wearer; mult_player_movespeed_active
-					TF2Items_SetAttribute(itemNew, 2, 6, 0.50); // set faster firing speed to +50%; 
+					TF2Items_SetAttribute(itemNew, 0, 6, 0.50); // +50% faster firing speed
+					TF2Items_SetAttribute(itemNew, 1, 851, 1.00); // +0% faster move speed on wearer
+					TF2Items_SetAttribute(itemNew, 2, 855, 0.0); // mod maxhealth drain rate
 				}
 				default: {
 					TF2Items_SetNumAttributes(itemNew, 2);
-					TF2Items_SetAttribute(itemNew, 0, 855, 0.0); // mod maxhealth drain rate
-					TF2Items_SetAttribute(itemNew, 1, 852, 1.20); // dmg taken increased
+					TF2Items_SetAttribute(itemNew, 0, 852, 1.20); // mult_dmgtaken_active
+					TF2Items_SetAttribute(itemNew, 1, 855, 0.0); // mod maxhealth drain rate
 				}
 			}
 			// Eviction Notice stacking speedboost on hit with reverted Buffalo Steak Sandvich handled elsewhere
@@ -4222,7 +4222,7 @@ Action SDKHookCB_OnTakeDamage(
 								// increase crit vuln here for proper resist on crits and minicrits
 								// (multiplicative inverse of spunup resist value)
 								TF2Attrib_SetByDefIndex(weapon1, 63, 1.0 / spunup_resist); // mult_dmgtaken_from_crit
-								TF2Attrib_SetByDefIndex(weapon1, 412, spunup_resist); // mult_dmgtaken
+								TF2Attrib_SetByDefIndex(weapon1, 852, spunup_resist); // mult_dmgtaken_active
 								TF2Attrib_SetByDefIndex(weapon1, 738, 1.0); // spunup_damage_resistance
 							}
 						}
@@ -5089,7 +5089,7 @@ void SDKHookCB_OnTakeDamagePost(
 						) {
 							// remove temp attribs
 							TF2Attrib_RemoveByDefIndex(weapon1, 63);
-							TF2Attrib_RemoveByDefIndex(weapon1, 412);
+							TF2Attrib_RemoveByDefIndex(weapon1, 852);
 							TF2Attrib_RemoveByDefIndex(weapon1, 738);
 						}
 					}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4211,11 +4211,14 @@ Action SDKHookCB_OnTakeDamage(
 							GetItemVariant(Wep_Natascha) == 0 &&
 							GetEntProp(weapon1, Prop_Send, "m_iItemDefinitionIndex") == 41
 						) {
-							// play damage resist sound
-							EmitGameSoundToAll("Player.ResistanceLight", victim);
-
 							float spunup_resist = TF2Attrib_HookValueFloat(1.0, "spunup_damage_resistance", weapon1);
-							if (spunup_resist > 0.0) {
+							if (
+								spunup_resist > 0.0 &&
+								spunup_resist != 1.0
+							) {
+								// play damage resist sound
+								EmitGameSoundToAll("Player.ResistanceLight", victim);
+
 								// increase crit vuln here for proper resist on crits and minicrits
 								// (multiplicative inverse of spunup resist value)
 								TF2Attrib_SetByDefIndex(weapon1, 63, 1.0 / spunup_resist); // mult_dmgtaken_from_crit

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -594,7 +594,7 @@
 	}
 	"BrassBeast_PreMYM"
 	{
-		"en"	"Reverted to pre-matchmaking, 20%% damage resistance (6.7%% against crits) when spun up at any health"
+		"en"	"Reverted to pre-matchmaking, 20%% damage resistance when spun up regardless of health (6.7%% against crits)"
 	}
 	"Bushwacka_PreLW"
 	{
@@ -842,7 +842,7 @@
 	}
 	"Natascha_PreMYM"
 	{
-		"en"	"Reverted to pre-matchmaking, 20%% damage resistance (6.7%% against crits) when spun up at any health"
+		"en"	"Reverted to pre-matchmaking, 20%% damage resistance when spun up regardless of health (6.7%% against crits)"
 	}
 	"Natascha_PreGM"
 	{


### PR DESCRIPTION
### Summary of changes
fix (mini-)crit resist for reverted brass beast and natascha
also preserves the spunup resist attribute

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested in itemtest

### Other Info
fixes #61 
