### PR TITLE
make the 85 base bash damage more obvious for splendid screen reverts

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1138,11 +1138,11 @@
 	}
 	"Splendid_PreTB"
 	{
-		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal, full bash dmg at any range"
+		"en"	"Reverted to pre-toughbreak, 15%% blast resist, no faster recharge, crit after bash, no debuff removal, full 85 base bash dmg at any range"
 	}
 	"Splendid_Release"
 	{
-		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal, full bash dmg at any range"
+		"en"	"Reverted to release, 25%% fire resist, no faster recharge, crit after bash, no debuff removal, full 85 base bash dmg at any range"
 	}
 	"SpyCicle_PreGM"
 	{


### PR DESCRIPTION
### Summary of changes
[A quick summary of changes from this PR]

### Testing Attestation
- [ ] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
[Any other information you'd like to provide]
