### PR TITLE
add flame DPS info for flamethrower revert for clarity

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -530,7 +530,7 @@
 	}
 	"Flamethrower_PreBM"
 	{
-		"en"	"Reverted to pre-bluemoon, full dmg with no density ramp up"
+		"en"	"Reverted to pre-bluemoon, full dmg with no density ramp up (around +30%% more flame dmg per sec)"
 	}
 	"Grenade_Pre2014"
 	{


### PR DESCRIPTION
### Summary of changes
based from the video:
https://www.youtube.com/watch?v=Aa18zFYDDRs
point blank DPS increase: +35% DPS estimated
swinging fire DPS increase: +29% DPS estimated
averaging the two, we get around +30% estimated more DPS +30% more DPS is more clear to players

### Testing Attestation
- [ ] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
[Any other information you'd like to provide]
