### PR TITLE
fix base jumper revert

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -284,7 +284,7 @@ ConVar cvar_ref_tf_feign_death_duration;
 ConVar cvar_ref_tf_feign_death_speed_duration;
 ConVar cvar_ref_tf_fireball_radius;
 ConVar cvar_ref_tf_gamemode_mvm;
-ConVar cvar_ref_tf_parachute_aircontrol;
+ConVar cvar_ref_tf_parachute_maxspeed_xy;
 ConVar cvar_ref_tf_parachute_maxspeed_onfire_z;
 ConVar cvar_ref_tf_parachute_deploy_toggle_allowed;
 ConVar cvar_ref_tf_scout_hype_mod;
@@ -784,7 +784,7 @@ public void OnPluginStart() {
 	cvar_ref_tf_feign_death_speed_duration = FindConVar("tf_feign_death_speed_duration");
 	cvar_ref_tf_fireball_radius = FindConVar("tf_fireball_radius");
 	cvar_ref_tf_gamemode_mvm = FindConVar("tf_gamemode_mvm");
-	cvar_ref_tf_parachute_aircontrol = FindConVar("tf_parachute_aircontrol");
+	cvar_ref_tf_parachute_maxspeed_xy = FindConVar("tf_parachute_maxspeed_xy");
 	cvar_ref_tf_parachute_maxspeed_onfire_z = FindConVar("tf_parachute_maxspeed_onfire_z");
 	cvar_ref_tf_parachute_deploy_toggle_allowed = FindConVar("tf_parachute_deploy_toggle_allowed");
 	cvar_ref_tf_scout_hype_mod = FindConVar("tf_scout_hype_mod");
@@ -2091,7 +2091,7 @@ public void OnGameFrame() {
 
 			// these cvars are global, set them to the desired value
 			SetConVarMaybe(cvar_ref_tf_fireball_radius, "30.0", ItemIsEnabled(Wep_DragonFury));
-			SetConVarMaybe(cvar_ref_tf_parachute_aircontrol, "5", ItemIsEnabled(Wep_BaseJumper));
+			SetConVarMaybe(cvar_ref_tf_parachute_maxspeed_xy, "400.0", ItemIsEnabled(Wep_BaseJumper));
 			SetConVarMaybe(cvar_ref_tf_parachute_maxspeed_onfire_z, "10.0", ItemIsEnabled(Wep_BaseJumper));
 			SetConVarMaybe(cvar_ref_tf_parachute_deploy_toggle_allowed, "1", ItemIsEnabled(Wep_BaseJumper));
 


### PR DESCRIPTION
### Summary of changes
fixes the base jumper revert, which erroneously changes a different cvar than it should be changing

before:
`tf_parachute_aircontrol 5`
`tf_parachute_maxspeed_xy 300.0` (default)

after:
`tf_parachute_aircontrol 2.5` (default)
`tf_parachute_maxspeed_xy 400.0`

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
i dont feel like setting up sourcemod right now

### Other Info

--- parachute cvars from live tf2 ---

https://github.com/ValveSoftware/source-sdk-2013/blob/2d3a6efb50bba856a44e73d4f0098ed4a726699c/src/game/shared/tf/tf_gamemovement.cpp#L53-L58

<img width="790" height="190" alt="image" src="https://github.com/user-attachments/assets/dd58fda4-ba08-4c45-b4ab-053893582fea" />

--- parachute cvars from pre-toughbreak tf2 ---

downloaded with: `DepotDownloader -app 232250 -depot 232256 -manifest 72506409595626366`

https://steamdb.info/depot/232256/history/?changeid=M:72506409595626366

decompiled with ghidra

<img width="850" height="450" alt="image" src="https://github.com/user-attachments/assets/0bf78144-13d8-4835-b4df-8b38f166042d" />

<img width="850" height="450" alt="image" src="https://github.com/user-attachments/assets/a10ce2f2-8c17-4b38-9815-7e231b6ee4a5" />


