### PR TITLE
Added Huntsman staring contest revert.

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -83,7 +83,20 @@
 				"library" "server"
 				"windows" "\x55\x8B\xEC\x83\xEC\x3C\x8B\x01"
 				"linux"   "@_ZN10CHealthKit7MyTouchEP11CBasePlayer"
-			}		
+			}
+			// Left in here if ever needed someday
+			// "GetSceneDuration" // First FUN_ in OnTauntSucceeded (find that one using the string set_taunt_saharan_spy), above mult_gesture_time
+			// {
+			// 	"library" "server"
+			//	"windows" "\x55\x8B\xEC\x83\xEC\x10\x8B\x0D\x2A\x2A\x2A\x2A\x8D\x55\x2A\x56"
+			//	"linux"   "@_Z16GetSceneDurationPKc"
+			// }
+			"CTFPlayer::OnTauntSucceeded" // find using string set_taunt_saharan_spy
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\x83\xEC\x10\x53\x56\x57\xFF\x75"
+				"linux"   "@_ZN9CTFPlayer16OnTauntSucceededEPKcii"
+			}
 		}
 
 		"Offsets"
@@ -139,6 +152,32 @@
 			{
 				"windows" "229"
 				"linux"   "230"
+			}
+
+			// ╔══════════════════════════════════════════════╗
+			// ║       Private/Protected Member Offsets       ║
+			// ╚══════════════════════════════════════════════╝
+			// Add offsets below for when you need OS specific offsets for a m_ member on a entity
+			// This is used for Set/GetEntData and stuff like Set/GetEntDataFloat that we cannot 
+			// find in datamaps and netprop files.
+			// If it's a m_h* member that you intend to add offset for. 
+			// Then use the "*2" version of the methods, for example: GetEntDataEnt2 when using the offset.
+			//
+			// See the Huntsman Staring Contest revert for a example of usage with a normal m_ member.
+			// ============================================
+			// m_flTauntNextStartTime
+			// Find it by searching for 2.0 in the decompile text for CTFPlayer::OnTauntSucceeded
+			// example of what the code can look like in the windows binary (will not be exact due to tf2 updates etc)
+			// *(float *)((int)this + 0x2144) = *(float *)((int)this + 0x2140) + 2.0;
+			// it's the this + 0x2144 and 0x2144 is the offset (translate it from HEX to Decimal).
+			// always verify with the machine code, as sometimes the decompile text is lying (click the displayed
+			// offset in Ghidra and then look at the Listing view. As of the October 30, 2025 patch it's
+			// f3 0f 11 86 44 21 00 00, notice how memory is displayed in little endian, but you can see the 44 21 turns into 21 44)
+
+			"m_flTauntNextStartTime" 
+			{
+				"windows" "8516"
+				"linux"   "8524"
 			}
 		}
 
@@ -393,6 +432,42 @@
 					"pPlayer"
 					{
 						"type" "cbaseentity"
+					}
+				}
+			}
+			// Left in here if ever needed someday.
+//			"GetSceneDuration" 
+//			{
+//				"signature" "GetSceneDuration"
+//				"callconv"  "cdecl"
+//				"return"    "float"
+//				"arguments"
+//				{
+//					"pszSceneName"
+//					{
+//						"type" "charptr"
+//					}
+//				}
+//			}
+			"CTFPlayer::OnTauntSucceeded"
+			{
+				"signature"   "CTFPlayer::OnTauntSucceeded"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"   "void"
+				"arguments"
+				{
+					"pszSceneName"
+					{
+						"type" "charptr"
+					}
+					"iTauntIndex"
+					{
+						"type" "int"
+					}
+					"iTauntConcept"
+					{
+						"type" "int"
 					}
 				}
 			}


### PR DESCRIPTION
### Summary of changes
Sets m_flTauntNextStartTime on a sniper using huntsman taunt to GetGameTime()
whenever revert is turned on with 
sm_reverts__enable_huntsman_staring_contest 1

Doing this allows Snipers to spam the taunt so they can keep skewering eachother
forever until the weaker Sniper surrenders to the might of the most superior
Australian!

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Tested in Linux and Windows using a bot,
spammed the bound bot taunt command and my own taunt command (G)
with bot_mirror bot01 for the bot so it could also have huntsman.

### Other Info
Thanks to @num-get for research.
Thanks to @antielectronbomb for testing and helping with theory crafting.
Solves #314 
