### PR TITLE
(Reverts) Allow Crossbow Heal Uber Gain for Historically Accurate Amputator Variant

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1875,7 +1875,7 @@ public void OnGameFrame() {
 								StrEqual(class, "tf_weapon_medigun") &&
 								GetItemVariant(Wep_Amputator) == 1 &&
 								player_weapons[idx][Wep_Amputator] &&
-								TF2_IsPlayerInCondition(idx, TFCond_Taunting)							
+								TF2_IsPlayerInCondition(idx, TFCond_Taunting)
 							) {
 								if (!players[idx].medic_crossbow_heal) {
 									SetEntPropFloat(weapon, Prop_Send, "m_flChargeLevel", players[idx].medic_amputator_current_uber);


### PR DESCRIPTION
### Summary of changes
This uses the taunt DHook for this to work. Extremely esoteric fix for an extremely esoteric bug. See https://github.com/rsedxcftvgyhbujnkiqwe/castaway-plugins/pull/340#issuecomment-3650727864

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
itemtest dev room, put a heavy bot at one corner, some bots at the other corner, and you at the corner. Use host_timescale 0.1 to make it easier to fire a crossbow bolt and then taunt heal with the amputator. You should have Uber gain with the Crossbow. Historically accurate Amputator variant still works as intended when taunting.

### Other Info
[Any other information you'd like to provide]
