### PR TITLE
(Reverts) Fully Revert Projectile Hitbox of the Pomson and Bison

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4504,20 +4504,23 @@ void SDKHookCB_SpawnPost(int entity) {
 				if (
 					(ItemIsEnabled(Wep_Bison) && StrEqual(class, "tf_weapon_raygun")) ||
 					(ItemIsEnabled(Wep_Pomson) && StrEqual(class, "tf_weapon_drg_pomson"))
-				) {
-					maxs[0] = 4.0;	// equals to ~48.0 HU in the X axis
-					maxs[1] = 4.0;	// equals to ~48.0 HU in the Y axis
-					maxs[2] = 32.0;	// 10.0 equals to ~26.0 HU; 32.0 equals to ~48.0 HU in the Z axis
-					// old pomson/bison hitbox was a cube that was about 48 HU on all sides and only its center would collide with world
+				) {	// old pomson/bison projectile hitbox was a cube that was about 48 HU on all sides and only around its center would it collide with world
+					maxs[0] = 2.0;	// 2.0 equals to ~48.0 HU in the X axis with m_triggerBloat set to 26
+					maxs[1] = 2.0;	// 2.0 equals to ~48.0 HU in the Y axis with m_triggerBloat set to 26
+					maxs[2] = 8.0;	// 8.0 equals to ~48.0 HU in the Z axis with m_triggerBloat set to 26 & with m_bUniformTriggerBloat set to true
+					
 					mins[0] = (0.0 - maxs[0]);
 					mins[1] = (0.0 - maxs[1]);
 					mins[2] = (0.0 - maxs[2]);
-
+					// m_vecMaxs and m_vecMins is the actual size of the projectile hitbox which can collide with world geometry (bounding box)
 					SetEntPropVector(entity, Prop_Send, "m_vecMaxs", maxs);
 					SetEntPropVector(entity, Prop_Send, "m_vecMins", mins);
-
+					// m_triggerBloat increases the size of the projectile's trigger hitbox but not the bounding box size. This means that the trigger hitbox does not collide with world geometry.
 					SetEntProp(entity, Prop_Send, "m_usSolidFlags", (GetEntProp(entity, Prop_Send, "m_usSolidFlags") | FSOLID_USE_TRIGGER_BOUNDS));
-					SetEntProp(entity, Prop_Send, "m_triggerBloat", 24);
+					SetEntProp(entity, Prop_Send, "m_bUniformTriggerBloat", true); // m_triggerBloat only increases the trigger hitbox in X and Y axes; this is necessary to resize the Z axis
+					SetEntProp(entity, Prop_Send, "m_triggerBloat", 26); // using m_triggerBloat ensures that the projectile does not collide with world geometry but still increases the trigger hitbox against players and buildings
+					// setting the maxs values to 2.0 and m_triggerBloat to 26 ensures that the projectile hitbox is a 48 HU cube, just like the old projectile hitbox
+					// as for why its 26, its to account for the default hitbox being a 2 HU cube, and through experimental testing via puppet bots, cl_showpos, getpos, and setpos
 				}
 			}
 		}


### PR DESCRIPTION
### Summary of changes
This basically makes the hitbox of the Pomson and Bison projectiles bigger, especially in the Z axis, so you can jump and shoot above someone's head and still deal damage.

Fully reverts the projectile hitbox of the Pomson and Bison by setting m_bUniformTriggerBloat to true, adjusting maxs[2] to 8.0 and setting m_triggerBloat to 26, so that the hitbox is a 48x48x48 HU cube projectile hitbox which collides only with the world at its center and collides with players and entities with the 48 HU cube hitbox.

Closes #359 

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested with itemtest, calculator, and indirect maths

my notes for posterity:
```
december 28, 2025
	bot -class heavy -team blu
	bot_command bot01 addcond 73; bot_command bot01 addcond 130

	maxs[0] = 2.0;
	maxs[1] = 2.0;
	maxs[2] = 12.0;

	pomson/bison hitbox notes
	LEFT HAND VIEWMODELS, SHOOT FROM LEFT
	
	bot_teleport bot01 1695.853516 -2320.800537 -116.968681 0 90 0
	FOR X AXIS TESTING (256 HU AWAY):
		setpos 1695.853516 -2064.800537 -116.968681; setang 0 -90 0
	FOR Y AXIS TESTING (256 HU AWAY):
		setpos 1951.853516 -2320.800537 -116.968681; setang 0 180 0
	FOR Z AXIS TESTING:
		Z coordinate floor pos = -123.968681
		Z coordinate top hitbox alignment = -109.448463
			setpos 1695.853516 -2064.800537 -109.448463; setang 0 -90 0
			since it teleports a bit above, use this:
				setpos 1695.853516 -2064.800537 -177.968681; setang 0 -90 0
		Z coordinate last touch
				setpos 1695.853516 -2064.800537 -151.968681; setang 0 -90 0
				
				if maxs[2] = 24.0
					setpos 1695.853516 -2064.800537 -139.968681; setang 0 -90 0
				if maxs[2] = 48.0
					setpos 1695.853516 -2064.800537 -115.968681; setang 0 -90 0
				if maxs[2] = 40.0
					setpos 1695.853516 -2064.800537 -123.968681; setang 0 -90 0
				if maxs[2] = 30.0
					setpos 1695.853516 -2064.800537 -133.968681; setang 0 -90 0
				if maxs[2] = 32.0
					setpos 1695.853516 -2064.800537 -131.968681; setang 0 -90 0
				if maxs[2] = 4.0 && m_bUniformTriggerBloat is TRUE
					setpos 1695.853516 -2064.800537 -135.968681; setang 0 -90 0
				if maxs[2] = 10.0 && m_bUniformTriggerBloat is TRUE && m_triggerBloat = 26
					setpos 1695.853516 -2064.800537 -128; setang 0 -90 0
	TEST FOR MAKING SURE ACTUAL PROJECTILE HITBOX DOES NOT COLLIDE WITH WORLD
		setpos 2035 -260 -235;setang 0.000000 -90.000000 0.000000
		+attack
		make sure the projectile doesn't collide with the wall or floor, only at the other far end

	X coordinate (last touch): 
		1742 - 1696 = 46 units ~ close enough to 48 units (actual size of old pomson hitbox)
		if maxs[4]
			1743 - 1696 = 47 units ~ very close
		if maxs[2] && m_bUniformTriggerBloat = TRUE && m_triggerBloat = 26
			1744 - 1696 = 48 units = exactly like the old hitbox size
	Y coordinate (last touch): 
		-2321 - -2366 = 45 units ~ close enough to 48 units (actual size of old pomson hitbox)
		if maxs[4]
			2368 - 2321 = 47 units ~ very close
		if maxs[2] && m_bUniformTriggerBloat = TRUE && m_triggerBloat = 26
			2368 - 2321 = 47 units ~ very close to the old hitbox size. practically 48 units.
	Z coordinate (last touch): 
		178 - 152 = 26 units -> not accurate to true size
		178 - 140 = 38 units -> not accurate to true size (48 units)
		178 - 116 = 62 units -> not accurate (too big)
		178 - 134 = 44 units ~ close enough to 48 units (actual size of old pomson hitbox)
		178 - 132 = 46 units ~ more close enough to 48 units (actual size of old pomson hitbox)
		178 - 136 = 42 units - close but not close enough, but at least we know that m_bUniformTriggerBloat DOES something
			apparently m_triggerBloat only increases by 24 in the X and Y axes, and does not include the Z axis.
			however, by setting m_bUniformTriggerBloat to TRUE, it includes the Z axis.
		if maxs[2] = 2.0 && m_bUniformTriggerBloat = TRUE && m_triggerBloat = 26
			178 - 136 = 42 units - close but not close enough
		if maxs[2] = 4.0 && m_bUniformTriggerBloat = TRUE && m_triggerBloat = 26
			178 - 134 = 44 units
		if maxs[2] = 10.0 && m_bUniformTriggerBloat = TRUE && m_triggerBloat = 26
			178 - 128 = 50 units (too much)
		if maxs[2] = 8.0 && m_bUniformTriggerBloat = TRUE && m_triggerBloat = 26
			178 - 130 = 48 units = exactly like old hitbox size
```

### Other Info
added some comments
