### PR TITLE
Add full drain cloak info for Release Pomson 6000

### DIFF
--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1098,7 +1098,7 @@
 	}
 	"Sandman_PreClassless"
 	{
-		"en"	"Reverted to pre-Classless Update, full stuns, can stun invuln players, stun victims receive 50%% damage, no health penalty, no double jump, 15 sec ball recharge time"
+		"en"	"Reverted to pre-Classless Update, full stuns, can stun invuln players, stun victims receive 50%% damage, no health penalty, no double jump, 15 sec ball recharge time, no alt-fire"
 	}
 	"Sandvich_PreEngineer"
 	{


### PR DESCRIPTION
Updated description for Pomson_Release to include full drain cloak effect against disguised and/or cloaked Spies.
Added "All" to "Sniper Quickscopes" and "no alt-fire" to pre-classless sandman

### Summary of changes
[A quick summary of changes from this PR]

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
[Any other information you'd like to provide]
