### PR TITLE
Changed Buffalo Steak variant 1 and 2 to give throwing heavy health instead of recharging meter when picked up.

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -631,7 +631,7 @@ public void OnPluginStart() {
 	ItemVariant(Wep_Bushwacka, "Bushwacka_PreGM");
 	ItemDefine("buffalosteak", "BuffaloSteak_PreMYM", CLASSFLAG_HEAVY, Wep_BuffaloSteak);
 	ItemVariant(Wep_BuffaloSteak, "BuffaloSteak_Release");
-	ItemVariant(Wep_BuffaloSteak, "BuffaloSteak_Pre2013");
+	ItemVariant(Wep_BuffaloSteak, "BuffaloSteak_Pre2012");
 	ItemDefine("buffbanner", "BuffBanner_Release", CLASSFLAG_SOLDIER | ITEMFLAG_DISABLED, Wep_BuffBanner);
 	ItemDefine("targe", "Targe_PreTB", CLASSFLAG_DEMOMAN, Wep_CharginTarge);
 	ItemDefine("claidheamh", "Claidheamh_PreTB", CLASSFLAG_DEMOMAN, Wep_Claidheamh);
@@ -1871,7 +1871,6 @@ public void OnGameFrame() {
 							// hence the weird comments inside the if statement.
 							(GetItemVariant(Wep_Sandvich) == 0 && player_weapons[idx][Wep_Sandvich])
 //							||
-//							(GetItemVariant(Wep_BuffaloSteak) > 0 && player_weapons[idx][Wep_BuffaloSteak])
 //							()
 						) {
 							weapon = GetPlayerWeaponSlot(idx, TFWeaponSlot_Secondary);
@@ -1881,8 +1880,7 @@ public void OnGameFrame() {
 							if (	
 								item_def_idx == 42 || // Sandvich
 								item_def_idx == 863 || // Robo-Sandvich
-								item_def_idx == 1002 // || // Festive Sandvich
-							//	item_def_idx == 311 // Buffalo Steak Sandvich (Kept just because. LOL)
+								item_def_idx == 1002 // Festive Sandvich
 							) {
 								timer = GetEntPropFloat(idx, Prop_Send, "m_flItemChargeMeter", LOADOUT_POSITION_SECONDARY);
 								// Before every gameframe when has_thrown_sandvich is true on this heavy.							

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -676,9 +676,9 @@
 	{
 		"en"	"Reverted to release, +35%% faster move speed on use, damage taken minicrits, no speed cap (stacks with GRU), heal yourself by throwing the Steak"
 	}
-	"BuffaloSteak_Pre2013"
+	"BuffaloSteak_Pre2012"
 	{
-		"en"	"Reverted to pre-Summer 2013, +35%% faster move speed on use, damage taken minicrits, heal yourself by throwing the Steak"
+		"en"	"Reverted to pre-February 14, 2012; +35%% faster move speed on use, damage taken minicrits, heal yourself by throwing the Steak"
 	}
 	"BuffBanner_Release"
 	{


### PR DESCRIPTION
### Summary of changes
See commit.
I was unsure if the steak variants should be allowing
recharging over time. I left the code commented for now (the steaks recharge on their own).

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
Tested very briefly in Linux, but not nearly enough. I don't have the time due to New Years approaching.

### Other Info
Needs testing in Windows and Linux and needs testing with turning Sandvich and Buffalo Steak cvars to different combinations.
