### PR TITLE
(Reverts) Pre-Gun Mettle Vaccinator

### DIFF
--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -95,7 +95,7 @@ sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
 sm_reverts__item_splendid 2
-sm_reverts__item_spycicle 1
+sm_reverts__item_spycicle 2
 sm_reverts__item_stkjumper 2
 sm_reverts__item_sleeper 3
 sm_reverts__item_thermal 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -126,7 +126,7 @@ sm_reverts__item_turner 1
 sm_reverts__item_tomislav 3
 sm_reverts__item_tribalshiv 0
 sm_reverts__item_caber 1
-sm_reverts__item_vaccinator 1
+sm_reverts__item_vaccinator 2
 sm_reverts__item_vitasaw 1
 sm_reverts__item_warrior 1
 // warrior's spirit lacks pre-GM version, this is the closest version

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -232,6 +232,11 @@
 				"windows"	"482"
 				"linux"		"489"
 			}
+			"CWeaponMedigun::CanAttack"
+			{
+				"windows" "428"
+				"linux"   "435"
+			}
 
 			// ╔══════════════════════════════════════════════╗
 			// ║       Private/Protected Member Offsets       ║

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -234,8 +234,13 @@
 			}
 			"CWeaponMedigun::CanAttack"
 			{
-				"windows" "428"
-				"linux"   "435"
+				"windows"	"428"
+				"linux"		"435"
+			}
+			"CWeaponMedigun::ItemPostFrame"
+			{
+				"windows"	"273"
+				"linux"		"279"
 			}
 
 			// ╔══════════════════════════════════════════════╗
@@ -267,6 +272,7 @@
 
 		"Functions"
 		{
+			// Offset
 			"CTFWeaponBase::PrimaryAttack"
 			{
 				"offset" "CTFWeaponBase::PrimaryAttack"
@@ -387,7 +393,15 @@
 				"this"		"entity"
 				"return"	"float"
 			}
+			"CWeaponMedigun::ItemPostFrame"
+			{
+				"offset"   "CWeaponMedigun::ItemPostFrame"
+				"hooktype" "entity"
+				"this"     "entity"
+				"return"   "void"
+			}
 
+			// Signature
 			"CTFPlayer::CanDisguise"
 			{
 				"signature" "CTFPlayer::CanDisguise"

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -146,6 +146,12 @@
 				"windows" "\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x2A\x89\x6C\x24\x2A\x8B\xEC\x83\xEC\x28\x56\x57\x8B\xF9\x6A\x39"
 				"linux"   "@_ZN15CTFPlayerShared18AddToSpyCloakMeterEfb"
 			}
+			"CWeaponMedigun::FindAndHealTargets" // offset aMultMedigunUbe ; "mult_medigun_uberchargerate"
+			{
+				"library" "server"
+				"windows" "\x55\x8B\xEC\x83\xEC\x20\x53\x56\x8B\xF1\x8B\x8E"
+				"linux"   "@_ZN14CWeaponMedigun18FindAndHealTargetsEv"
+			}
 		}
 
 		"Offsets"
@@ -717,6 +723,13 @@
 						"type" "bool"
 					}
 				}
+			}
+			"CWeaponMedigun::FindAndHealTargets"
+			{
+				"signature" "CWeaponMedigun::FindAndHealTargets"
+				"callconv"  "thiscall"
+				"this"      "entity"
+				"return"    "bool"
 			}
 		}
 	}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1900,7 +1900,9 @@ public void OnGameFrame() {
 									TFCond resistance = view_as<TFCond>(GetResistType(weapon) + TF_COND_RESIST_OFFSET);
 
 									if (players[idx].using_vaccinator_uber) {
+										// Deplete Vaccinator charge
 										players[idx].vaccinator_charge -= 0.25 * 0.5 * GetTickInterval();
+										// End Vaccinator charge, and remove the resist conditions
 										if (players[idx].vaccinator_charge <= players[idx].vaccinator_charge_end) {
 											players[idx].using_vaccinator_uber = false;
 											TF2_RemoveCondition(idx, resistance);
@@ -1914,6 +1916,7 @@ public void OnGameFrame() {
 											SetEntPropFloat(weapon, Prop_Send, "m_flChargeLevel", players[idx].vaccinator_charge);
 										}
 									}
+									// If heal target changes or weapons are switched, remove/add the resist conditions if ubered
 									if (
 										entities[weapon].patient != patient ||
 										weapon != GetEntPropEnt(idx, Prop_Send, "m_hActiveWeapon")

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -7643,7 +7643,7 @@ MRESReturn DHookCallback_CWeaponMedigun_FindAndHealTargets_Pre(int entity) {
 			flMod = TF2Attrib_HookValueFloat(flMod, "mult_patient_overheal_penalty", patient);
 			weapon = GetEntPropEnt(patient, Prop_Send, "m_hActiveWeapon");
 			if (weapon > 0) {
-				flMod = TF2Attrib_HookValueFloat(flMod, "mult_player_movespeed_active", weapon);
+				flMod = TF2Attrib_HookValueFloat(flMod, "mult_patient_overheal_penalty_active", weapon);
 			}
 			if (
 				flMod <= 0.0 &&

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1294,7 +1294,7 @@
 	}	
 	"Vaccinator_PreGM"
 	{
-		"en"	"Pre-GM: full crit base resist, bubbles gone when cut off, no Uber rate penalties, only 1 resist on patient, 25%% HP regen on proper resist, +50%% Uber rate, -66%% overheal build rate"
+		"en"	"Reverted to pre-gunmettle, +50%% Uber rate, no Uber rate penalties, full crit base resist, bubbles last 2s and are gone when cut off, only 1 resist on patient, 25%% HP regen on proper resist"
 	}
 	"VitaSaw_PreJI"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1294,7 +1294,7 @@
 	}	
 	"Vaccinator_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, +50%% Uber rate, no overhealed Uber rate penalties, no Uber rate penalty from multiple healers, full crit base resist, bubbles last 2s and are gone when cut off, only 1 resist on patient, 25%% HP regen on proper resist"
+		"en"	"Pre-GM: full crit base resist, bubbles gone when cut off, no overhealed Uber rate penalties, no Uber rate penalty from multiple healers, only 1 resist on patient, 25%% HP regen on proper resist, +50%% Uber rate, -66%% overheal build rate"
 	}
 	"VitaSaw_PreJI"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1294,7 +1294,7 @@
 	}	
 	"Vaccinator_PreGM"
 	{
-		"en"	"Reverted to pre-gunmettle, +50%% Uber rate, no Uber rate penalties, full crit base resist, bubbles last 2s and are gone when cut off, only 1 resist on patient, 25%% HP regen on proper resist"
+		"en"	"Reverted to pre-gunmettle, +50%% Uber rate, no overhealed Uber rate penalties, no Uber rate penalty from multiple healers, full crit base resist, bubbles last 2s and are gone when cut off, only 1 resist on patient, 25%% HP regen on proper resist"
 	}
 	"VitaSaw_PreJI"
 	{

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1292,10 +1292,10 @@
 	{
 		"en"	"Reverted to pre-toughbreak, +50%% Uber rate, -66%% Uber rate on overhealed patients, you are healed for 10%% of the matched incoming damage on patient"
 	}	
-	// "Vaccinator_PreGM"
-	// {
-	// 	"en"	"Pre-GM: full crit base resist, bubbles gone when cut off, no overhealed patient Uber rate penalty, no penalties when healed by other Medics, only 1 resist on patient, 25%% HP regen on proper resist, +50%% Uber rate, -66%% overheal build rate"
-	// }
+	"Vaccinator_PreGM"
+	{
+		"en"	"Pre-GM: full crit base resist, bubbles gone when cut off, no Uber rate penalties, only 1 resist on patient, 25%% HP regen on proper resist, +50%% Uber rate, -66%% overheal build rate"
+	}
 	"VitaSaw_PreJI"
 	{
 		"en"	"Reverted to pre-inferno, always preserves up to 20%% uber on death"


### PR DESCRIPTION
### Summary of changes
Reverted to pre-gunmettle, +50% Uber rate, no Uber rate penalties, full crit base resist, bubbles last 2s and are gone when cut off, only 1 resist on patient, 25% HP regen on proper resist

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
tested on bots

### Other Info
Partially ported from NotnHeavy's. Closes #374 