### PR TITLE
(Revert) Fix Release Spycicle melting when hit by fire during taunting

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2193,6 +2193,25 @@ public void OnGameFrame() {
 							}							
 						}
 					}
+
+					{
+						// release spycicle prevent melting when hit by fire while taunting
+						if (GetItemVariant(Wep_Spycicle) == 1) {
+							weapon = GetEntPropEnt(idx, Prop_Send, "m_hActiveWeapon");
+
+							if (weapon > 0) {
+								if (
+									GetItemVariant(Wep_Spycicle) == 1 &&
+									GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 649 &&
+									TF2_IsPlayerInCondition(idx, TFCond_Taunting) &&
+									(TF2_IsPlayerInCondition(idx, TFCond_FireImmune) || TF2_IsPlayerInCondition(idx, TFCond_OnFire))
+								) {
+									SetEntPropFloat(weapon, Prop_Send, "m_flKnifeRegenerateDuration", 0.0);
+									// PrintToChatAll("Hit by fire, regenerated Spycicle while taunting");
+								}
+							}
+						}
+					}						
 				} else {
 					// reset if player isn't spy
 					players[idx].spy_is_feigning = false;

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -1230,7 +1230,7 @@
 	}
 	"SpyCicle_Pre2011"
 	{
-		"en"	"Reverted to release, fire immunity for 2s, silent killer, cannot regenerate from ammo sources, uses the Fencing taunt attack"
+		"en"	"Reverted to release, fire immunity for 2s, silent killer, cannot regenerate from ammo sources, uses the Fencing taunt attack, does not melt during taunting while active"
 	}
 	"StkJumper_Pre2013"
 	{


### PR DESCRIPTION
### Summary of changes
Basically forces the Spycicle to regenerate whenever the Spy is on fire or has the fire immunity condition from the spycicle via `m_flKnifeRegenerateDuration`
Historical evidence: https://www.youtube.com/watch?v=TnkRN-sty6U

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
itemtest

### Other Info
TO DO: add historical video to the wiki, update wiki
