### PR TITLE
(Reverts) Various fixes/improvements 10

### DIFF
--- a/cfg/reverts_bakugo_original.cfg
+++ b/cfg/reverts_bakugo_original.cfg
@@ -89,7 +89,7 @@ sm_reverts__item_scorchshot 0
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 1
 sm_reverts__item_shortstop 1
-sm_reverts__item_sodapop 1
+sm_reverts__item_sodapop 2
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 0
 sm_reverts__item_splendid 0

--- a/cfg/reverts_castaway.cfg
+++ b/cfg/reverts_castaway.cfg
@@ -89,7 +89,7 @@ sm_reverts__item_scorchshot 0
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 0
 sm_reverts__item_shortstop 1
-sm_reverts__item_sodapop 1
+sm_reverts__item_sodapop 2
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
 sm_reverts__item_splendid 1

--- a/cfg/reverts_enable_itemsets.cfg
+++ b/cfg/reverts_enable_itemsets.cfg
@@ -52,8 +52,8 @@ sm_reverts__item_amputator 1
 // SNIPER - The Croc-o-Style Kit
 // Darwin's Danger Shield is reverted to release for historical accuracy, as well as the Bushwacka.
 sm_reverts__item_crocostyle 1
-sm_reverts__item_sleeper 3
-sm_reverts__item_darwin 1
+sm_reverts__item_sleeper 2
+sm_reverts__item_darwin 2
 sm_reverts__item_bushwacka 1
 
 

--- a/cfg/reverts_high.cfg
+++ b/cfg/reverts_high.cfg
@@ -89,7 +89,7 @@ sm_reverts__item_scorchshot 1
 sm_reverts__item_scottish 1
 sm_reverts__item_circuit 1
 sm_reverts__item_shortstop 1
-sm_reverts__item_sodapop 1
+sm_reverts__item_sodapop 2
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
 sm_reverts__item_splendid 1

--- a/cfg/reverts_light.cfg
+++ b/cfg/reverts_light.cfg
@@ -90,7 +90,7 @@ sm_reverts__item_scorchshot 0
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 0
 sm_reverts__item_shortstop 1
-sm_reverts__item_sodapop 0
+sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 0
 sm_reverts__item_splendid 0

--- a/cfg/reverts_medium.cfg
+++ b/cfg/reverts_medium.cfg
@@ -90,7 +90,7 @@ sm_reverts__item_scorchshot 0
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 0
 sm_reverts__item_shortstop 1
-sm_reverts__item_sodapop 2
+sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
 sm_reverts__item_splendid 0

--- a/cfg/reverts_mvm.cfg
+++ b/cfg/reverts_mvm.cfg
@@ -88,7 +88,7 @@ sm_reverts__item_scorchshot 1
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 0
 sm_reverts__item_shortstop 3
-sm_reverts__item_sodapop 1
+sm_reverts__item_sodapop 2
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
 sm_reverts__item_splendid 2

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -88,10 +88,10 @@ sm_reverts__item_sandvich 2
 sm_reverts__item_scorchshot 1
 sm_reverts__item_scottish 0
 // release scottish resistance was just awful to use
-sm_reverts__item_circuit 0
-// modern short circuit is the most powerful version
+sm_reverts__item_circuit 3
+// smissmas 2013 is the most braindead version
 sm_reverts__item_shortstop 3
-sm_reverts__item_sodapop 1
+sm_reverts__item_sodapop 2
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 1
 sm_reverts__item_splendid 2

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -66,7 +66,7 @@ sm_reverts__item_lochload 1
 sm_reverts__item_cannon 1
 sm_reverts__item_madmilk 1
 sm_reverts__item_gardener 1
-sm_reverts__item_natascha 1
+sm_reverts__item_natascha 3
 sm_reverts__item_panic 0
 // modern panic attack has the most versatility
 sm_reverts__item_persuader 2

--- a/cfg/reverts_powerful.cfg
+++ b/cfg/reverts_powerful.cfg
@@ -38,7 +38,7 @@ sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 1
 sm_reverts__item_crossbow 1
 sm_reverts__item_dalokohsbar 1
-sm_reverts__item_darwin 0
+sm_reverts__item_darwin 1
 sm_reverts__item_ringer 6
 sm_reverts__item_degreaser 1
 sm_reverts__item_directhit 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -115,7 +115,7 @@ sm_reverts__item_scorchshot 0
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 2
 sm_reverts__item_shortstop 2
-sm_reverts__item_sodapop 2
+sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 1
 sm_reverts__item_spdelivery 0
 sm_reverts__item_splendid 1

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -57,7 +57,7 @@ sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 0
 sm_reverts__item_crossbow 0
 sm_reverts__item_dalokohsbar 2
-sm_reverts__item_darwin 2
+sm_reverts__item_darwin 1
 sm_reverts__item_ringer 1
 sm_reverts__item_degreaser 1
 sm_reverts__item_directhit 0

--- a/cfg/reverts_pregunmettle.cfg
+++ b/cfg/reverts_pregunmettle.cfg
@@ -2,7 +2,7 @@
 // Reverts weapons currently available in the plug-in to their pre-Gun Mettle versions as much as possible
 // The state that the weapons are reverted to is right before the Gun Mettle Update.
 // If there is no pre-Gun Mettle weapon revert available, the weapon revert is turned off or reverted to its closest version.
-// For reverted weapons released after Jungle Inferno, they are left enabled (currently only 1 reverted weapon from Jungle Inferno).
+// For reverted weapons released after Jungle Inferno, they are left disabled as to not show up in the reverts list if they happen to be blacklisted.
 // There are a lot more weapons that aren't reverted to pre-Gun Mettle in this plugin.
 // Use this config at your own discretion. If you would like to help contribute to the plugin, please do.
 
@@ -62,7 +62,7 @@ sm_reverts__item_ringer 1
 sm_reverts__item_degreaser 1
 sm_reverts__item_directhit 0
 sm_reverts__item_disciplinary 1
-sm_reverts__item_dragonfury 1
+sm_reverts__item_dragonfury 0
 sm_reverts__item_enforcer 1
 sm_reverts__item_equalizer 0
 sm_reverts__item_eureka 0
@@ -122,8 +122,7 @@ sm_reverts__item_splendid 1
 sm_reverts__item_spycicle 1
 sm_reverts__item_stkjumper 0
 sm_reverts__item_sleeper 2
-sm_reverts__item_thermal 1
-// enabling thermal thruster revert since it was like this in jungle inferno
+sm_reverts__item_thermal 0
 sm_reverts__item_turner 1
 // tide turner lacks pre-GM version. i'm enabling this regardless since its the closest
 sm_reverts__item_tomislav 3

--- a/cfg/reverts_prejungleinferno.cfg
+++ b/cfg/reverts_prejungleinferno.cfg
@@ -2,7 +2,7 @@
 // Reverts weapons currently available in the plug-in to their pre-Jungle Inferno versions as much as possible
 // The state that the weapons are reverted to is right before the Jungle Inferno Update.
 // If there is no pre-Jungle Inferno weapon revert available, the weapon revert is turned off or reverted to its closest version.
-// For reverted weapons released after Jungle Inferno, they are left enabled. Use a server whitelist instead if you want to remove such weapons.
+// For reverted weapons released after Jungle Inferno, they are left disabled as to not show up in the reverts list if they happen to be blacklisted.
 // Use this config at your own discretion. If you would like to help contribute to the plugin, please do.
 
 // Editor's Note: The Jungle Inferno Update is the update the changed Pyro's weapons alot.
@@ -57,9 +57,7 @@ sm_reverts__item_ringer 2
 sm_reverts__item_degreaser 0
 sm_reverts__item_directhit 1
 sm_reverts__item_disciplinary 0
-sm_reverts__item_dragonfury 1
-// enabling dragon's fury regardless. people tend to complain whenever weapons are removed
-// if you want to remove the jungle inferno weapons, do it via server whitelist instead
+sm_reverts__item_dragonfury 0
 sm_reverts__item_enforcer 0
 sm_reverts__item_equalizer 0
 sm_reverts__item_eureka 0
@@ -112,8 +110,7 @@ sm_reverts__item_splendid 0
 sm_reverts__item_spycicle 0
 sm_reverts__item_stkjumper 0
 sm_reverts__item_sleeper 1
-sm_reverts__item_thermal 1
-// enabling thermal thruster revert since it was like this in jungle inferno
+sm_reverts__item_thermal 0
 sm_reverts__item_turner 0
 sm_reverts__item_tomislav 0
 sm_reverts__item_tribalshiv 0

--- a/cfg/reverts_prejungleinferno.cfg
+++ b/cfg/reverts_prejungleinferno.cfg
@@ -52,7 +52,7 @@ sm_reverts__item_critcola 2
 sm_reverts__item_crocostyle 0
 sm_reverts__item_crossbow 1
 sm_reverts__item_dalokohsbar 1
-sm_reverts__item_darwin 2
+sm_reverts__item_darwin 1
 sm_reverts__item_ringer 2
 sm_reverts__item_degreaser 0
 sm_reverts__item_directhit 1

--- a/cfg/reverts_pretoughbreak.cfg
+++ b/cfg/reverts_pretoughbreak.cfg
@@ -103,7 +103,7 @@ sm_reverts__item_scorchshot 0
 sm_reverts__item_scottish 0
 sm_reverts__item_circuit 1
 sm_reverts__item_shortstop 0
-sm_reverts__item_sodapop 2
+sm_reverts__item_sodapop 1
 sm_reverts__item_solemn 0
 sm_reverts__item_spdelivery 0
 sm_reverts__item_splendid 1

--- a/cfg/reverts_pretoughbreak.cfg
+++ b/cfg/reverts_pretoughbreak.cfg
@@ -50,7 +50,7 @@ sm_reverts__item_critcola 1
 sm_reverts__item_crocostyle 0
 sm_reverts__item_crossbow 0
 sm_reverts__item_dalokohsbar 1
-sm_reverts__item_darwin 2
+sm_reverts__item_darwin 1
 sm_reverts__item_ringer 3
 // most nerfed version of the dead ringer
 sm_reverts__item_degreaser 1

--- a/cfg/reverts_pretoughbreak.cfg
+++ b/cfg/reverts_pretoughbreak.cfg
@@ -2,7 +2,7 @@
 // Reverts weapons currently available in the plug-in to their pre-tough break versions as much as possible
 // The state that the weapons are reverted to is right before the Tough Break Update.
 // If there is no pre-Tough Break weapon revert available, the weapon revert is turned off or reverted to its closest version.
-// For reverted weapons released after Tough Break, they are left enabled. Use a server whitelist instead if you want to remove such weapons.
+// For reverted weapons released after Tough Break, they are left disabled as to not show up in the reverts list if they happen to be blacklisted.
 // Use this config at your own discretion. If you would like to help contribute to the plugin, please do.
 
 // Editor's note: The Tough Break Update is the update that pretty much changed Demoknight's weapons.
@@ -56,8 +56,7 @@ sm_reverts__item_ringer 3
 sm_reverts__item_degreaser 1
 sm_reverts__item_directhit 1
 sm_reverts__item_disciplinary 1
-sm_reverts__item_dragonfury 1
-// enabling dragon's fury regardless. people tend to complain whenever weapons are removed
+sm_reverts__item_dragonfury 0
 sm_reverts__item_enforcer 0
 sm_reverts__item_equalizer 0
 sm_reverts__item_eureka 0
@@ -110,8 +109,7 @@ sm_reverts__item_splendid 1
 sm_reverts__item_spycicle 0
 sm_reverts__item_stkjumper 0
 sm_reverts__item_sleeper 1
-sm_reverts__item_thermal 1
-// enabling thermal thruster revert regardless
+sm_reverts__item_thermal 0
 sm_reverts__item_turner 1
 sm_reverts__item_tomislav 0
 sm_reverts__item_tribalshiv 0

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -4293,20 +4293,10 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 			{
 				bool validSet = false;
 
-				if (active_set == Set_CrocoStyle)
-				{
-					// This code only checks for Darwin's Danger Shield (231)
-					// this code can also be used if you want cosmetics to be a part of item sets
-					for (int i = 0; i < TF2Util_GetPlayerWearableCount(client); i++)
-					{
-						weapon = TF2Util_GetPlayerWearable(client, i);
-						index = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
-						if (index == 231) {
-							validSet = true;
-							break;
-						}
-					}
-				} else {
+				if (
+					active_set != Set_CrocoStyle ||
+					active_set == Set_CrocoStyle && player_weapons[client][Wep_Darwin]
+				) {
 					validSet = true;
 				}
 
@@ -5271,26 +5261,6 @@ Action SDKHookCB_OnTakeDamage(
 					return Plugin_Changed;
 				}
 			}
-
-			{
-				// Natascha stun. Stun amount/duration taken from TF2 source code. Imported from NotnHeavy's pre-GM plugin
-				if (
-					GetItemVariant(Wep_Natascha) >= 1 &&
-					StrEqual(class, "tf_weapon_minigun") &&
-					GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 41
-				) {
-					GetEntPropVector(attacker, Prop_Send, "m_vecOrigin", pos1);
-					GetEntPropVector(victim, Prop_Send, "m_vecOrigin", pos2);
-
-					// Slow enemy on hit, unless they're being healed by a medic
-					if (
-						!TF2_IsPlayerInCondition(victim, TFCond_Healing) &&
-						GetVectorDistance(pos1, pos2, true) > Pow(512.0, 2.0)
-					) {
-						TF2_StunPlayer(victim, 0.20, 0.60, TF_STUNFLAG_SLOWDOWN, attacker);
-					}
-				}
-			}
 		
 			{
 				// Cow Mangler Revert No Crit Boost Attribute Fix for all variants
@@ -5729,6 +5699,23 @@ Action SDKHookCB_OnTakeDamageAlive(
 				// TFCond_DefenseBuffMmmph applies 75% resistance normally, buff it here by 60% for 90% resistance
 				damage *= 0.40; // will also resist taunt kills!
 				returnValue = Plugin_Changed;
+			}
+		}
+
+		if (weapon > 0) {
+			GetEntityClassname(weapon, class, sizeof(class));
+
+			{
+				// Natascha stun. Stun amount/duration taken from TF2 source code. Imported from NotnHeavy's pre-GM plugin
+				if (
+					GetItemVariant(Wep_Natascha) >= 1 &&
+					StrEqual(class, "tf_weapon_minigun") &&
+					GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex") == 41 &&
+					!TF2_IsPlayerInCondition(victim, TFCond_Healing)
+				) {
+					// Slow enemy on hit, unless they're being healed by a medic
+					TF2_StunPlayer(victim, 0.20, 0.60, TF_STUNFLAG_SLOWDOWN, attacker);
+				}
 			}
 		}
 	}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -5705,6 +5705,7 @@ void SDKHookCB_OnTakeDamagePost(
 					Address m_flFeignDeathEnd = GetEntityAddress(victim) + CTFPlayerShared_m_flFeignDeathEnd;
 					float feign_end = LoadFromAddress(m_flFeignDeathEnd, NumberType_Int32);
 					StoreToAddress(m_flFeignDeathEnd, feign_end - damage * 0.01667, NumberType_Int32);
+					// ^ would like to know the exact formula here, this is an approximation of the tick-based formula what was used in the plugin
 				}
 
 				charge = GetEntPropFloat(victim, Prop_Send, "m_flCloakMeter");

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -703,8 +703,8 @@ public void OnPluginStart() {
 	ItemVariant(Wep_CritCola, "CritCola_Release");
 	ItemDefine("dalokohsbar", "DalokohsBar_PreJI", CLASSFLAG_HEAVY, Wep_Dalokohs);
 	ItemVariant(Wep_Dalokohs, "DalokohsBar_PreGM");
-	ItemDefine("darwin", "Darwin_Pre2013", CLASSFLAG_SNIPER, Wep_Darwin);
-	ItemVariant(Wep_Darwin, "Darwin_PreJI");
+	ItemDefine("darwin", "Darwin_PreJI", CLASSFLAG_SNIPER, Wep_Darwin);
+	ItemVariant(Wep_Darwin, "Darwin_Pre2013");
 	ItemDefine("ringer", "Ringer_PreGM", CLASSFLAG_SPY, Wep_DeadRinger);
 	ItemVariant(Wep_DeadRinger, "Ringer_PreJI");
 	ItemVariant(Wep_DeadRinger, "Ringer_PreTB");
@@ -3036,7 +3036,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		}}
 		case 231: { if (ItemIsEnabled(Wep_Darwin)) {
 			switch (GetItemVariant(Wep_Darwin)) {
-				case 1: {
+				case 0: {
 					TF2Items_SetNumAttributes(itemNew, 5);
 					TF2Items_SetAttribute(itemNew, 0, 26, 25.0); // +25 max health on wearer
 					TF2Items_SetAttribute(itemNew, 1, 60, 1.0); // +0% fire damage resistance on wearer
@@ -3044,7 +3044,7 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 					TF2Items_SetAttribute(itemNew, 3, 66, 0.85); // +15% bullet damage resistance on wearer
 					TF2Items_SetAttribute(itemNew, 4, 527, 0.0); // remove afterburn immunity
 				}
-				default: {
+				case 1: {
 					TF2Items_SetNumAttributes(itemNew, 3);
 					TF2Items_SetAttribute(itemNew, 0, 26, 25.0); // +25 max health on wearer
 					TF2Items_SetAttribute(itemNew, 1, 60, 1.0); // +0% fire damage resistance on wearer

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -5749,6 +5749,10 @@ void SDKHookCB_OnTakeDamagePost(
 
 				charge = GetEntPropFloat(victim, Prop_Send, "m_flCloakMeter");
 				if (
+					(
+						GetItemVariant(Wep_DeadRinger) == 0 ||
+						GetItemVariant(Wep_DeadRinger) >= 3
+					) &&
 					charge < 100.0 &&
 					players[victim].feign_ready_tick == GetGameTickCount()
 				) {


### PR DESCRIPTION
### Summary of changes
see commits

**Contains breaking changes:**
- Stickybomb revert is disabled by default
- Pre-JI Darwin's Danger Shield is the base variant again
- Pre-MyM Soda Popper is now the base variant

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
[Any other information you'd like to provide]
