### PR TITLE
add a forward to allow other plugins to block afk kick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ scripting/include/*
 !scripting/include/tf2utils.inc
 !scripting/include/sourcescramble.inc
 !scripting/include/scramble.inc
+!scripting/include/afkmanager.inc
 
 !gamedata/
 gamedata/*

--- a/scripting/afkmanager.sp
+++ b/scripting/afkmanager.sp
@@ -25,6 +25,12 @@ ConVar g_cvAfkSpecTime;
 ConVar g_cvAfkSpecMovedTime;
 ConVar g_cvMinPlayerCount;
 
+GlobalForward g_fwOnAfkKick;
+
+public APLRes AskPluginLoad2(Handle plugin, bool late, char[] error, int err_max) {
+    RegPluginLibrary("afkmanager");
+}
+
 public void OnPluginStart()
 {
 	g_cvEnabled = CreateConVar("sm_afkmanager_enabled","1","Enable AFK Manager", _, true, 0.0, true, 1.0);
@@ -33,6 +39,8 @@ public void OnPluginStart()
     g_cvAfkSpecTime = CreateConVar("sm_afkmanager_spec_time", "300", "How long a player must be AFK in spectator before they are kicked, in seconds.", _, true, 60.0);
     g_cvAfkSpecMovedTime = CreateConVar("sm_afkmanager_spec_moved_time", "60", "How long a player must be AFK in spectator for, after being moved to it due to being afk, before they are kicked, in seconds.", _, true, 60.0);
     g_cvMinPlayerCount = CreateConVar("sm_afkmanager_min_player_count", "12", "Minimum number of players on the server before the AFK manager starts taking action on players.");
+
+	g_fwOnAfkKick = new GlobalForward("OnAFKKick", ET_Hook, Param_Cell);
 
 	AutoExecConfig(true, "afkmanager", "sourcemod");
 
@@ -107,8 +115,16 @@ void ClientPressedButton(int client) {
 	g_bMovedToSpec[client] = false;
 }
 
-void Kick(int client) {
-	KickClient(client,"#TF_Idle_kicked");
+bool Kick(int client) {
+	Action result = Plugin_Continue;
+	Call_StartForward(g_fwOnAfkKick);
+	Call_PushCell(client);
+	Call_Finish(result);
+	if (result == Plugin_Continue) {
+		KickClient(client,"#TF_Idle_kicked");
+		return true;
+	}
+	return false;
 }
 
 void AfkManage() {
@@ -152,14 +168,19 @@ void AfkManage() {
 			) {
 				if (action==0) {
 					if (elapsed > spec_time) {
-						Kick(idx);
+						// reset last pressed time when a plugin is tring to block it
+						if (!Kick(idx)) {
+							ClientPressedButton(idx);
+						}
 					}
 				} else if (action==1) {
 					if (
 						(g_bMovedToSpec[idx] && elapsed > spec_moved_time) ||
 						(!g_bMovedToSpec[idx] && elapsed > spec_time)
 					) {
-						Kick(idx);
+						if (!Kick(idx)) {
+							ClientPressedButton(idx);
+						}
 					}
 				}
 			} else if (
@@ -174,7 +195,9 @@ void AfkManage() {
 				}
 				if (elapsed > alive_time) {
 					if (action==0) {
-						Kick(idx);
+						if (!Kick(idx)) {
+							ClientPressedButton(idx);
+						}
 					} else if (action==1) {
 						TF2_ChangeClientTeam(idx, TFTeam_Spectator);
 						ClientPressedButton(idx);

--- a/scripting/include/afkmanager.inc
+++ b/scripting/include/afkmanager.inc
@@ -9,8 +9,8 @@
  * @param client    Client index.
  * @returns         Return Plugin_Continue to continue the kick, return a
  *                  higher value to block the kick. When blocked, it will
- * 					reset the internal AFK time and will get called again
- * 					when the client continues to be AFK.
+ * 					reset the internal AFK time for the client and will 
+ * 					get called again when the client continues to be AFK.
  */
 forward Action OnAFKKick(int client);
 

--- a/scripting/include/afkmanager.inc
+++ b/scripting/include/afkmanager.inc
@@ -1,0 +1,25 @@
+#if defined _AFKMANAGER_INCLUDED
+	#endinput
+#endif
+#define _AFKMANAGER_INCLUDED
+
+/**
+ * Called when an AFK kick is about to be performed.
+ * 
+ * @param client    Client index.
+ * @returns         Return Plugin_Continue to continue the kick, return a
+ *                  higher value to block the kick. When blocked, it will
+ * 					reset the internal AFK time and will get called again
+ * 					when the client continues to be AFK.
+ */
+forward Action OnAFKKick(int client);
+
+public SharedPlugin __pl_afkmanager = {
+	name = "afkmanager",
+	file = "afkmanager.smx",
+#if defined REQUIRE_PLUGIN
+	required = 1,
+#else
+	required = 0,
+#endif
+};


### PR DESCRIPTION
### Summary of changes
Adds a forward to allow other plugins to block AFK kick.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Like this
```sourcepawn
public Action OnAFKKick(int client) {
    return Plugin_Handled;
}
```

### Other Info
N/A
