### PR TITLE
(Reverts) Allow Heavy to secondary attack while stunned (historical bug)

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -195,6 +195,14 @@
 				"windows"	"\x55\x8B\xEC\x83\xEC\x70\x53\x8B\x5D\x2A\x56\x57\x8B\xF9\x89\x7D"
 				"linux"		"@_ZN11CBaseObject14InputWrenchHitEP9CTFPlayerP9CTFWrench6Vector"
 			}
+			// getting here is a fucking mess. i had to get the pointer to cvar "tf_max_charge_speed", which led to CTFGameMovement::ProcessMovement
+			// because CTFGameMovement::ChargeMove was inlined yet somehow this wasn't. any other possible path was screwed by them being virtual functions
+			"CTFGameMovement::StunMove"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x51\x53\x56\x8B\xF1\x8B\x8E"
+				"linux"		"@_ZN15CTFGameMovement8StunMoveEv"
+			}
 		}
 
 		"Offsets"
@@ -304,6 +312,21 @@
 			{
 				"windows"	"76"
 				"linux"		"76"
+			}
+			"CTFGameMovement.mv"
+			{
+				"windows"	"8"
+				"linux"		"8"
+			}
+			"CMoveData.m_nButtons"
+			{
+				"windows"	"36"
+				"linux"		"36"
+			}
+			"CTFGameMovement.m_pTFPlayer"
+			{
+				"windows"	"5816"
+				"linux"		"5816"
 			}
 		}
 
@@ -865,6 +888,13 @@
 						"size"	"12"
 					}
 				}
+			}
+			"CTFGameMovement::StunMove"
+			{
+				"signature"	"CTFGameMovement::StunMove"
+				"callconv"	"thiscall"
+				"this"		"address"
+				"return"	"bool"
 			}
 		}
 	}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -305,6 +305,7 @@ ConVar cvar_allow_detonate_stickies_while_taunting;
 #endif
 ConVar cvar_pre_toughbreak_switch;
 ConVar cvar_enable_shortstop_shove;
+ConVar cvar_enable_heavy_stun_attack;
 ConVar cvar_ref_tf_airblast_cray;
 ConVar cvar_ref_tf_damage_disablespread;
 ConVar cvar_ref_tf_dropped_weapon_lifetime;
@@ -615,6 +616,7 @@ public void OnPluginStart() {
 	cvar_no_reverts_info_by_default = CreateConVar("sm_reverts__no_reverts_info_on_spawn", "0", (PLUGIN_NAME ... " - Disable loadout change reverts info by default"), _, true, 0.0, true, 1.0);
 	cvar_pre_toughbreak_switch = CreateConVar("sm_reverts__pre_toughbreak_switch", "0", (PLUGIN_NAME ... " - Use pre-toughbreak weapon switch time (0.67 sec instead of 0.5 sec)"), _, true, 0.0, true, 1.0);
 	cvar_enable_shortstop_shove = CreateConVar("sm_reverts__enable_shortstop_shove", "0", (PLUGIN_NAME ... " - Enable alt-fire shove for reverted Shortstop"), _, true, 0.0, true, 1.0);
+	cvar_enable_heavy_stun_attack = CreateConVar("sm_reverts__enable_heavy_stun_attack", "1", (PLUGIN_NAME ... " - Allow stunned Heavies to secondary attack on all weapons while stunned (historical bug)"), _, true, 0.0, true, 1.0);
 
 #if defined MEMORY_PATCHES
 	cvar_dropped_weapon_enable.AddChangeHook(OnDroppedWeaponCvarChange);
@@ -7401,6 +7403,9 @@ MRESReturn DHookCallback_CTFWeaponBaseMelee_OnSwingHit(int entity, DHookReturn r
 }
 
 MRESReturn DHookCallback_CTFGameMovement_StunMove(Address pThis, DHookReturn returnValue) {
+	if (cvar_enable_heavy_stun_attack.BoolValue == false)
+		return MRES_Ignored;
+
 	int client = GetEntityFromAddress(LoadFromAddress(pThis + CTFGameMovement_m_pTFPlayer, NumberType_Int32));
 	if (
 		ItemIsEnabled(Wep_Sandman) &&

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -265,6 +265,7 @@ enum struct Player {
 	int charge_tick;
 	int fall_dmg_tick;
 	bool holding_jump;
+	bool holding_attack;
 	bool holding_attack2;
 	int drain_victim;
 	float drain_time;
@@ -411,6 +412,7 @@ DynamicDetour dhook_CTFPlayerShared_RemoveCond;
 DynamicDetour dhook_CTFPlayer_ApplyPunchImpulseX;
 DynamicDetour dhook_CTFWeaponBaseMelee_OnSwingHit;
 DynamicDetour dhook_CBaseObject_InputWrenchHit;
+DynamicDetour dhook_CTFGameMovement_StunMove;
 #if defined MEMORY_PATCHES
 DynamicDetour dhook_CTFAmmoPack_MakeHolidayPack;
 #endif
@@ -428,6 +430,9 @@ int CTFLunchBox_m_hThrownPowerUp;
 // We later load these with GameConfGetOffset(Handle gc, const char[] key)
 int CTFPlayer_m_flTauntNextStartTime;
 int CGameTrace_m_pEnt;
+Address CTFGameMovement_mv;
+Address CMoveData_m_nButtons;
+Address CTFGameMovement_m_pTFPlayer;
 
 Player players[MAXPLAYERS+1];
 Entity entities[2048];
@@ -945,15 +950,26 @@ public void OnPluginStart() {
 		dhook_CTFPlayer_ApplyPunchImpulseX = DynamicDetour.FromConf(conf, "CTFPlayer::ApplyPunchImpulseX");
 		dhook_CTFWeaponBaseMelee_OnSwingHit = DynamicDetour.FromConf(conf, "CTFWeaponBaseMelee::OnSwingHit");
 		dhook_CBaseObject_InputWrenchHit = DynamicDetour.FromConf(conf, "CBaseObject::InputWrenchHit");
+		dhook_CTFGameMovement_StunMove = DynamicDetour.FromConf(conf, "CTFGameMovement::StunMove");
 
 		// Load OS Specific Member offsets from reverts.txt for non-memorypatching purposes.
-		CTFPlayer_m_flTauntNextStartTime = -1;
-		CTFPlayer_m_flTauntNextStartTime = GameConfGetOffset(conf, "CTFPlayer.m_flTauntNextStartTime");
-		if (CTFPlayer_m_flTauntNextStartTime == -1) SetFailState("Failed to load m_flTauntNextStartTime offset!");
+		#define VALIDATE_OFFSET(%1) hook_fail |= ValidateOffset(#%1, %1)
 
-		CGameTrace_m_pEnt = -1;
+		CTFPlayer_m_flTauntNextStartTime = GameConfGetOffset(conf, "CTFPlayer.m_flTauntNextStartTime");
 		CGameTrace_m_pEnt = GameConfGetOffset(conf, "CGameTrace.m_pEnt");
-		if (CGameTrace_m_pEnt == -1) SetFailState("Failed to load CGameTrace_m_pEnt offset!");
+		CTFGameMovement_mv = view_as<Address>(GameConfGetOffset(conf, "CTFGameMovement.mv"));
+		CMoveData_m_nButtons = view_as<Address>(GameConfGetOffset(conf, "CMoveData.m_nButtons"));
+		CTFGameMovement_m_pTFPlayer = view_as<Address>(GameConfGetOffset(conf, "CTFGameMovement.m_pTFPlayer"));
+
+		VALIDATE_OFFSET(CTFPlayer_m_flTauntNextStartTime);
+		VALIDATE_OFFSET(CGameTrace_m_pEnt);
+		VALIDATE_OFFSET(CTFGameMovement_mv);
+		VALIDATE_OFFSET(CMoveData_m_nButtons);
+		VALIDATE_OFFSET(CTFGameMovement_m_pTFPlayer);
+
+		if (hook_fail) {
+			SetFailState("Failed to load offsets");
+		}
 
 		delete conf;
 	}
@@ -1075,6 +1091,7 @@ public void OnPluginStart() {
 	VALIDATE_HANDLE(dhook_CTFPlayer_ApplyPunchImpulseX);
 	VALIDATE_HANDLE(dhook_CTFWeaponBaseMelee_OnSwingHit);
 	VALIDATE_HANDLE(dhook_CBaseObject_InputWrenchHit);
+	VALIDATE_HANDLE(dhook_CTFGameMovement_StunMove);
 
 #if defined MEMORY_PATCHES
 	VALIDATE_PATCH(patch_RevertDragonsFury_CenterHitForBonusDmg);
@@ -1134,6 +1151,7 @@ public void OnPluginStart() {
 	dhook_CTFPlayer_ApplyPunchImpulseX.Enable(Hook_Pre, DHookCallback_CTFPlayer_ApplyPunchImpulseX);
 	dhook_CTFWeaponBaseMelee_OnSwingHit.Enable(Hook_Pre, DHookCallback_CTFWeaponBaseMelee_OnSwingHit);
 	dhook_CBaseObject_InputWrenchHit.Enable(Hook_Post, DHookCallback_CBaseObject_InputWrenchHit);
+	dhook_CTFGameMovement_StunMove.Enable(Hook_Post, DHookCallback_CTFGameMovement_StunMove);
 
 #if defined MEMORY_PATCHES
 	dhook_CTFAmmoPack_MakeHolidayPack.Enable(Hook_Pre, DHookCallback_CTFAmmoPack_MakeHolidayPack);
@@ -1218,6 +1236,15 @@ public void OnConfigsExecuted() {
 	UpdateStickyLauncherDescription();
 #endif
 	UpdateShortstopDescription();
+}
+
+bool ValidateOffset(const char[] name, any offset)
+{
+	if (offset == -1) {
+		LogError("Failed to load %s offset", name);
+		return true;
+	}
+	return false;
 }
 
 bool ValidateHandle(const char[] name, Handle handle)
@@ -5419,6 +5446,15 @@ public Action OnPlayerRunCmd(
 	} else {
 		players[client].holding_jump = false;
 	}
+
+	if (buttons & IN_ATTACK) {
+		if (!players[client].holding_attack) {
+			players[client].holding_attack = true;
+		}
+	} else {
+		players[client].holding_attack = false;
+	}
+
 	if (buttons & IN_ATTACK2) {
 		if (!players[client].holding_attack2) {
 			players[client].holding_attack2 = true;
@@ -7359,6 +7395,31 @@ MRESReturn DHookCallback_CTFWeaponBaseMelee_OnSwingHit(int entity, DHookReturn r
 			target <= MaxClients
 		) {
 			players[target].whip_frame = GetGameTickCount();
+		}
+	}
+	return MRES_Ignored;
+}
+
+MRESReturn DHookCallback_CTFGameMovement_StunMove(Address pThis, DHookReturn returnValue) {
+	int client = GetEntityFromAddress(LoadFromAddress(pThis + CTFGameMovement_m_pTFPlayer, NumberType_Int32));
+	if (
+		ItemIsEnabled(Wep_Sandman) &&
+		GetItemVariant(Wep_Sandman) < 3 &&
+		client >= 1 &&
+		client <= MaxClients
+	) {
+		// Allow Heavy to use secondary attack on any weapons while stunned. This was a historical bug.
+		if (
+			TF2_GetPlayerClass(client) == TFClass_Heavy &&
+			TF2_IsPlayerInCondition(client, TFCond_Dazed) &&
+			GetEntProp(client, Prop_Send, "m_iStunFlags") & (TF_STUNFLAG_BONKSTUCK | TF_STUNFLAG_THIRDPERSON) &&
+			!GetEntProp(client, Prop_Send, "m_bViewingCYOAPDA") &&
+			(players[client].holding_attack || players[client].holding_attack2)
+		) {
+			Address mv = LoadFromAddress(pThis + CTFGameMovement_mv, NumberType_Int32);
+			int buttons = LoadFromAddress(mv + CMoveData_m_nButtons, NumberType_Int32) | IN_ATTACK2;
+			StoreToAddress(mv + CMoveData_m_nButtons, buttons, NumberType_Int32);
+			SetEntProp(client, Prop_Data, "m_nButtons", buttons);
 		}
 	}
 	return MRES_Ignored;


### PR DESCRIPTION
### Summary of changes
Reverts a change from [March 28, 2018 Patch](https://wiki.teamfortress.com/wiki/March_28,_2018_Patch)
- Fixed the Heavy being able to attack with secondary and melee weapons while stunned

Also mentioned in the [old wiki page](https://wiki.teamfortress.com/w/index.php?title=Sandman&oldid=2227698):
- An enemy Heavy who is stunned with a melee weapon active will still be able to attack with that weapon.

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
[How was this tested? If this wasn't tested, why?]

### Other Info
implementing this was a mess, could use another way
