### PR TITLE
Make sourcescramble a requirement when MEMORY_PATCHES is enabled

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -40,9 +40,9 @@
 #include <tf2attributes>
 #include <dhooks>
 #include <morecolors> // Should be compiled on version 1.9.1 of morecolors.inc
-#undef REQUIRE_PLUGIN
+#if defined MEMORY_PATCHES
 #include <sourcescramble>
-#define REQUIRE_PLUGIN
+#endif
 #pragma semicolon 1
 #pragma newdecls required
 


### PR DESCRIPTION
### Summary of changes
Make sourcescramble a requirement when MEMORY_PATCHES is enabled

### Testing Attestation
- [ ] - This change has been tested
- [x] - This change has not been tested, reasoning below

### Description of testing
N/a

### Other Info
N/A