### PR TITLE
(Reverts) Rework Zatoichi and Powerjack heal

### DIFF
--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -316,6 +316,16 @@
 				"windows"	"430"
 				"linux"		"437"
 			}
+			"CTFPlayer::Event_KilledOther"
+			{
+				"windows"	"69"
+				"linux"		"70"
+			}
+			"CTFPlayer::TakeHealth"
+			{
+				"windows"	"66"
+				"linux"		"67"
+			}
 
 			// ╔══════════════════════════════════════════════╗
 			// ║       Private/Protected Member Offsets       ║
@@ -346,6 +356,11 @@
 			{
 				"windows"	"76"
 				"linux"		"76"
+			}
+			"CTakeDamageInfo.m_hWeapon"
+			{
+				"windows"	"44"
+				"linux"		"44"
 			}
 			"CTakeDamageInfo.m_flDamage"
 			{
@@ -638,6 +653,42 @@
 				"hooktype"	"entity"
 				"this"		"entity"
 				"return"	"void"
+			}
+			"CTFPlayer::Event_KilledOther"
+			{
+				"offset"	"CTFPlayer::Event_KilledOther"
+				"hooktype"	"entity"
+				"this"		"entity"
+				"return"	"void"
+				"arguments"
+				{
+					"pVictim"
+					{
+						"type"	"cbaseentity"
+					}
+					"info"
+					{
+						"type"	"int"
+					}
+				}
+			}
+			"CTFPlayer::TakeHealth"
+			{
+				"offset"	"CTFPlayer::TakeHealth"
+				"hooktype"	"entity"
+				"this"		"entity"
+				"return"	"int"
+				"arguments"
+				{
+					"flHealth"
+					{
+						"type"	"float"
+					}
+					"bitsDamageType"
+					{
+						"type"	"int"
+					}
+				}
 			}
 
 			// Signature

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -286,6 +286,8 @@ enum struct Player {
 	int fireproof_frame;
 	int cannonball_frame;
 	int old_metal;
+	int zatoichi_frame;
+	int powerjack_frame;
 }
 
 enum struct Entity {
@@ -393,6 +395,8 @@ DynamicHook dhook_CTFProjectile_HealingBolt_ImpactTeamPlayer;
 DynamicHook dhook_CBaseObject_InputWrenchHit;
 DynamicHook dhook_CBaseObject_Command_Repair;
 DynamicHook dhook_CWeaponMedigun_WeaponReset;
+DynamicHook dhook_CTFPlayer_Event_KilledOther;
+DynamicHook dhook_CTFPlayer_TakeHealth;
 
 DynamicDetour dhook_CTFPlayer_CanDisguise;
 DynamicDetour dhook_CTFPlayer_CalculateMaxSpeed;
@@ -435,6 +439,7 @@ int CTFPlayerShared_m_fEnergyDrinkConsumeRate;
 // Offsets loaded from gamedata
 int CTFPlayer_m_flTauntNextStartTime;
 Address CGameTrace_m_pEnt;
+Address CTakeDamageInfo_m_hWeapon;
 Address CTakeDamageInfo_m_flDamage;
 Address CTakeDamageInfo_m_iDamageCustom;
 
@@ -939,6 +944,8 @@ public void OnPluginStart() {
 		dhook_CBaseObject_InputWrenchHit = DynamicHook.FromConf(conf, "CBaseObject::InputWrenchHit");
 		dhook_CBaseObject_Command_Repair = DynamicHook.FromConf(conf, "CBaseObject::Command_Repair");
 		dhook_CWeaponMedigun_WeaponReset = DynamicHook.FromConf(conf, "CWeaponMedigun::WeaponReset");
+		dhook_CTFPlayer_Event_KilledOther = DynamicHook.FromConf(conf, "CTFPlayer::Event_KilledOther");
+		dhook_CTFPlayer_TakeHealth = DynamicHook.FromConf(conf, "CTFPlayer::TakeHealth");
 
 		dhook_CTFPlayer_CanDisguise = DynamicDetour.FromConf(conf, "CTFPlayer::CanDisguise");
 		dhook_CTFPlayer_CalculateMaxSpeed = DynamicDetour.FromConf(conf, "CTFPlayer::TeamFortress_CalculateMaxSpeed");
@@ -969,11 +976,13 @@ public void OnPluginStart() {
 
 		CTFPlayer_m_flTauntNextStartTime = GameConfGetOffset(conf, "CTFPlayer.m_flTauntNextStartTime");
 		CGameTrace_m_pEnt = view_as<Address>(GameConfGetOffset(conf, "CGameTrace.m_pEnt"));
+		CTakeDamageInfo_m_hWeapon = view_as<Address>(GameConfGetOffset(conf, "CTakeDamageInfo.m_hWeapon"));
 		CTakeDamageInfo_m_flDamage = view_as<Address>(GameConfGetOffset(conf, "CTakeDamageInfo.m_flDamage"));
 		CTakeDamageInfo_m_iDamageCustom = view_as<Address>(GameConfGetOffset(conf, "CTakeDamageInfo.m_iDamageCustom"));
 
 		VALIDATE_OFFSET(CTFPlayer_m_flTauntNextStartTime);
 		VALIDATE_OFFSET(CGameTrace_m_pEnt);
+		VALIDATE_OFFSET(CTakeDamageInfo_m_hWeapon);
 		VALIDATE_OFFSET(CTakeDamageInfo_m_flDamage);
 		VALIDATE_OFFSET(CTakeDamageInfo_m_iDamageCustom);
 
@@ -1076,6 +1085,8 @@ public void OnPluginStart() {
 	VALIDATE_HANDLE(dhook_CBaseObject_InputWrenchHit);
 	VALIDATE_HANDLE(dhook_CBaseObject_Command_Repair);
 	VALIDATE_HANDLE(dhook_CWeaponMedigun_WeaponReset);
+	VALIDATE_HANDLE(dhook_CTFPlayer_Event_KilledOther);
+	VALIDATE_HANDLE(dhook_CTFPlayer_TakeHealth);
 
 	VALIDATE_HANDLE(dhook_CTFPlayer_CanDisguise);
 	VALIDATE_HANDLE(dhook_CTFPlayer_CalculateMaxSpeed);
@@ -2039,6 +2050,8 @@ public void OnClientPutInServer(int client) {
 	SDKHook(client, SDKHook_OnTakeDamageAlive, SDKHookCB_OnTakeDamageAlive);
 	SDKHook(client, SDKHook_OnTakeDamagePost, SDKHookCB_OnTakeDamagePost);
 	SDKHook(client, SDKHook_WeaponSwitchPost, SDKHookCB_WeaponSwitchPost);
+	dhook_CTFPlayer_Event_KilledOther.HookEntity(Hook_Pre, client, DHookCallback_CTFPlayer_Event_KilledOther_Pre);
+	dhook_CTFPlayer_TakeHealth.HookEntity(Hook_Pre, client, DHookCallback_CTFPlayer_TakeHealth_Pre);
 }
 
 public void OnEntityCreated(int entity, const char[] class) {
@@ -3050,7 +3063,7 @@ public void ApplyRevertsToItem(int entity) {
 		}}
 		case 357: { if (ItemIsEnabled(Wep_Zatoichi)) {
 			TF2Attrib_SetByDefIndex(entity, 15, 1.0); // crit mod disabled
-			TF2Attrib_SetByDefIndex(entity, 220, 0.0); // restore health on kill
+			TF2Attrib_SetByDefIndex(entity, 220, 100.0); // restore health on kill
 			TF2Attrib_SetByDefIndex(entity, 226, 0.0); // honorbound
 			TF2Attrib_SetByDefIndex(entity, 781, 0.0); // is a sword
 		}}
@@ -3113,84 +3126,27 @@ public Action Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroad
 
 public Action Event_OnPlayerDeath(Event event, const char[] name, bool dontBroadcast) {
 	int client = GetClientOfUserId(GetEventInt(event, "userid"));
-	int attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
-	int weapon;
-	char class[64];
 
 	// 1 second sentry disable if wrangler shield active and engineer dies.
-	// should not affect the normal 3 second disable on engineer weapon switch etc.
 	if (
-		client > 0 &&
-		client <= MaxClients &&
-		IsClientInGame(client) &&
 		ItemIsEnabled(Wep_Wrangler) &&
-		GetItemVariant(Wep_Wrangler) < 2
-	) {
-		if (TF2_GetPlayerClass(client) == TFClass_Engineer) {
-
-			int sentry = FindSentryGunOwnedByClient(client);
-			if (sentry != -1) {
-
-				if (GetEntProp(sentry, Prop_Send, "m_bPlayerControlled") > 0) {
-
-					// Offset to m_flShieldFadeTime and input our own value.
-					SetEntDataFloat(sentry, CObjectSentrygun_m_flShieldFadeTime, GetGameTime() + 1.0);
-
-					// Set m_bPlayerControlled to 0 such that the original code
-					// wouldn't set the shield fade time to 3 seconds, thus undoing our revert.
-					SetEntProp(sentry, Prop_Send, "m_bPlayerControlled", 0);
-				} 
-			} 
-		} 
-	}
-
-	if (
-		client > 0 &&
+		GetItemVariant(Wep_Wrangler) < 2 &&
+		client >= 1 &&
 		client <= MaxClients &&
-		attacker > 0 &&
-		attacker <= MaxClients &&
 		IsClientInGame(client) &&
-		IsClientInGame(attacker)
+		TF2_GetPlayerClass(client) == TFClass_Engineer
 	) {
+		int sentry = FindSentryGunOwnedByClient(client);
 		if (
-			client != attacker &&
-			(GetEventInt(event, "death_flags") & TF_DEATH_FEIGN_DEATH) == 0 &&
-			GetEventInt(event, "inflictor_entindex") == attacker && // make sure it wasn't a "finished off" kill
-			IsPlayerAlive(attacker)
+			sentry != -1 &&
+			GetEntProp(sentry, Prop_Send, "m_bPlayerControlled") > 0
 		) {
-			weapon = GetEntPropEnt(attacker, Prop_Send, "m_hActiveWeapon");
+			// Offset to m_flShieldFadeTime and input our own value.
+			SetEntDataFloat(sentry, CObjectSentrygun_m_flShieldFadeTime, GetGameTime() + 1.0);
 
-			if (weapon > 0) {
-				GetEntityClassname(weapon, class, sizeof(class));
-
-				if (
-					ItemIsEnabled(Wep_Zatoichi) &&
-					StrEqual(class, "tf_weapon_katana")
-				) {
-					// zatoichi heal on kill
-					int health_max = SDKCall(sdkcall_GetMaxHealth, attacker);
-					if (GetClientHealth(attacker) < health_max) {
-						SetEntProp(attacker, Prop_Send, "m_iHealth", health_max);
-
-						Event healOnHitEvent = CreateEvent("player_healonhit", true);
-
-						healOnHitEvent.SetInt("amount", health_max);
-						healOnHitEvent.SetInt("entindex", attacker);
-						healOnHitEvent.SetInt("weapon_def_index", -1);
-
-						healOnHitEvent.Fire();
-					}
-				}
-
-				if (
-					ItemIsEnabled(Wep_Powerjack) &&
-					TF2Attrib_HookValueInt(0, "heal_on_kill", weapon) &&
-					GetEventInt(event, "customkill") == 0
-				) {
-					players[attacker].old_health = GetClientHealth(attacker);
-					RequestFrame(ApplyOverhealOnKill, weapon);
-				}
-			}
+			// Set m_bPlayerControlled to 0 such that the original code
+			// wouldn't set the shield fade time to 3 seconds, thus undoing our revert.
+			SetEntProp(sentry, Prop_Send, "m_bPlayerControlled", 0);
 		}
 	}
 	return Plugin_Continue;
@@ -5678,28 +5634,6 @@ void SetFeignDeathEnd(int client) {
 	SetEntDataFloat(client, CTFPlayerShared_m_flFeignDeathEnd, GetGameTime() + 6.0);
 }
 
-void ApplyOverhealOnKill(int weapon) {
-	if (!IsValidEntity(weapon))
-		return;
-
-	int owner = GetEntityOwner(weapon);
-
-	if (owner >= 1 && owner <= MaxClients) {
-		int health_cur = GetClientHealth(owner);
-
-		int heal_amt = TF2Attrib_HookValueInt(0, "heal_on_kill", weapon);
-		heal_amt = intMin(
-			TF2Util_GetPlayerMaxHealthBoost(owner) - health_cur,
-			heal_amt - (health_cur - players[owner].old_health)
-		);
-
-		if (heal_amt) {
-			// Apply overheal
-			TF2Util_TakeHealth(owner, float(heal_amt), TAKEHEALTH_IGNORE_MAXHEALTH);
-		}
-	}
-}
-
 void SetMeleeCrit(int client) {
 	if (!IsClientInGame(client))
 		return;
@@ -6805,12 +6739,11 @@ MRESReturn DHookCallback_CBaseCombatWeapon_ItemPostFrame_Pre(int entity) {
 		GetItemVariant(Wep_Vaccinator) == 1 &&
 		GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex") == 998 &&
 		owner >= 1 &&
-		owner <= MaxClients
+		owner <= MaxClients &&
+		players[owner].using_vaccinator_uber
 	) {
-		if (players[owner].using_vaccinator_uber) {
-			// Prevent resistance cycling while Ubering with the Vaccinator.
-			SetEntData(entity, CWeaponMedigun_m_bReloadDown, true, 1);
-		}
+		// Prevent resistance cycling while Ubering with the Vaccinator.
+		SetEntData(entity, CWeaponMedigun_m_bReloadDown, true, 1);
 	}
 	return MRES_Ignored;
 }
@@ -7366,6 +7299,58 @@ MRESReturn DHookCallback_CWeaponMedigun_WeaponReset_Post(int entity) {
 		float preserved = TF2Attrib_HookValueFloat(0.0, "preserve_ubercharge", owner) * 0.01;
 		charge = floatMax(charge, floatMin(old_charge_level, preserved));
 		SetEntPropFloat(entity, Prop_Send, "m_flChargeLevel", charge);
+	}
+	return MRES_Ignored;
+}
+
+MRESReturn DHookCallback_CTFPlayer_Event_KilledOther_Pre(int client, DHookParam parameters) {
+	Address info = parameters.Get(2);
+	int weapon = LoadEntityFromHandleAddress(info + CTakeDamageInfo_m_hWeapon);
+	if (
+		client >= 1 && client <= MaxClients &&
+		IsValidEntity(weapon)
+	) {
+		if (
+			ItemIsEnabled(Wep_Zatoichi) &&
+			TF2Attrib_HookValueInt(0, "restore_health_on_kill", weapon) > 50
+		) {
+			players[client].zatoichi_frame = GetGameTickCount();
+		}
+		if (
+			ItemIsEnabled(Wep_Powerjack) &&
+			TF2Attrib_HookValueInt(0, "heal_on_kill", weapon) != 0
+		) {
+			players[client].powerjack_frame = GetGameTickCount();
+		}
+	}
+	return MRES_Ignored;
+}
+
+MRESReturn DHookCallback_CTFPlayer_TakeHealth_Pre(int client, DHookReturn returnValue, DHookParam parameters) {
+	int flags;
+	if (client >= 1 && client <= MaxClients) {
+		if (
+			ItemIsEnabled(Wep_Zatoichi) &&
+			players[client].zatoichi_frame == GetGameTickCount()
+		) {
+			players[client].zatoichi_frame = 0;
+
+			flags = parameters.Get(2);
+			flags &= ~TAKEHEALTH_IGNORE_MAXHEALTH;
+			parameters.Set(2, flags);
+			return MRES_ChangedHandled;
+		}
+		if (
+			ItemIsEnabled(Wep_Powerjack) &&
+			players[client].powerjack_frame == GetGameTickCount()
+		) {
+			players[client].powerjack_frame = 0;
+
+			flags = parameters.Get(2);
+			flags |= TAKEHEALTH_IGNORE_MAXHEALTH;
+			parameters.Set(2, flags);
+			return MRES_ChangedHandled;
+		}
 	}
 	return MRES_Ignored;
 }


### PR DESCRIPTION
### Summary of changes
Preserves the attribute on the Half-Zatoichi, makes the code cleaner overall

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
walkway

### Other Info
N/A