### PR TITLE
Use gamedata to detect OS instead of compiler preprocessing 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,7 @@ jobs:
         run: |
           cd scripting
           cp reverts.sp reverts-patchless.sp
-          cp reverts.sp reverts-linux.sp
-          cp reverts.sp reverts-win32.sp
           sed -i "1i#define NO_MEMPATCHES" reverts-patchless.sp
-          sed -i "1i#define WIN32" reverts-win32.sp
           rm reverts.sp
 
       - name: Build reverts
@@ -76,12 +73,12 @@ jobs:
 
       - name: Package reverts
         run: |
-          for arch in "linux" "win32" "patchless"; do
-            FOLDER_NAME="reverts-${arch}_sm-${{ matrix.sm-target }}"
+          for arch in "" "-patchless"; do
+            FOLDER_NAME="reverts${arch}_sm-${{ matrix.sm-target }}"
             mkdir -p ${FOLDER_NAME}/plugins
             mkdir ${FOLDER_NAME}/gamedata
             mkdir ${FOLDER_NAME}/translations
-            mv scripting/compiled/reverts-${arch}.smx ${FOLDER_NAME}/plugins/reverts.smx
+            mv scripting/compiled/reverts${arch}.smx ${FOLDER_NAME}/plugins/reverts.smx
             cp gamedata/*reverts*.txt ${FOLDER_NAME}/gamedata/
             find translations/ -name "reverts.phrases.txt" -exec cp --parents {} ${FOLDER_NAME}/ \;
             zip -r "${FOLDER_NAME}.zip" "${FOLDER_NAME}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
           cd scripting
           cp reverts.sp reverts-patchless.sp
           sed -i "1i#define NO_MEMPATCHES" reverts-patchless.sp
-          rm reverts.sp
 
       - name: Build reverts
         run: |

--- a/gamedata/reverts.txt
+++ b/gamedata/reverts.txt
@@ -1,5 +1,21 @@
 "Games"
 {
+	"#default"
+	{
+		"Offsets"
+		{
+			// arbitrary values for detecting the operating system
+			"OperatingSystem"
+			{
+				"linux"		"0"
+				"windows"	"1"
+				"mac"		"2"
+				"linux64"	"3"
+				"windows64"	"4"
+				"mac64"		"5"
+			}
+		}
+	}
 	"tf"
 	{
 		"Signatures"

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -601,6 +601,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 		strcopy(error, err_max, "Gamedata has no OperatingSystem value");
 		return APLRes_Failure;
 	}
+	operatingSystem = view_as<OperatingSystem>(osOffset);
 	switch (operatingSystem) {
 		case MAC, MAC64: {
 			delete gamedata;

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -20,16 +20,6 @@
 #undef MEMORY_PATCHES
 #endif
 
-//#define WIN32
-/*
- ^ ^ ^ ^ ^ ^ ^ ^ ^
-	Additionally, you will need to select your compile OS.
-	Memory patches are different for Windows and Linux servers.
-	For Windows, either uncomment the above line
-	or pass in WIN32= as a parameter to spcomp.exe.
-	For Linux, leave this line commented.
-*/
-
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
@@ -56,13 +46,9 @@
 // To server owners, before you raise hell, do: sm plugins list 
 // and check that you compiled for the correct OS.
 #if defined MEMORY_PATCHES
-#if defined WIN32
-#define PLUGIN_VERSION PLUGIN_VERSION_NUM ... "-win32"
-#else
-#define PLUGIN_VERSION PLUGIN_VERSION_NUM ... "-linux32"
-#endif
-#else
 #define PLUGIN_VERSION PLUGIN_VERSION_NUM
+#else
+#define PLUGIN_VERSION PLUGIN_VERSION_NUM ... "-patchless"
 #endif
 
 //#define GIT_COMMIT
@@ -221,6 +207,16 @@ enum
 	SHOVEL_SPEED_BOOST,
 };
 
+enum OperatingSystem
+{
+	LINUX = 0,
+	WINDOWS,
+	MAC,
+	LINUX64,
+	WINDOWS64,
+	MAC64
+}
+
 char class_names[][] = {
 	"SCOUT",
 	"SNIPER",
@@ -344,14 +340,13 @@ Address AddressOf_g_flMadMilkHealTarget;
 MemoryPatch patch_RevertCannotDetonateStickiesWhileTaunting;
 
 float g_flWranglerSpreadTarget = 0.01745;
-#if defined WIN32
+// windows
 MemoryPatch patch_RevertWranglerSpreadCone_X;
 MemoryPatch patch_RevertWranglerSpreadCone_Y;
 MemoryPatch patch_RevertWranglerSpreadCone_Z;
-#else
+// linux
 MemoryPatch patch_RevertWranglerSpreadCone_SSE;
 Address AddressOf_g_flWranglerSpreadTarget;
-#endif
 
 float g_flSteakCapTarget = 10.0; // arbitrary
 float g_flSteakBoostTarget = 1.35;
@@ -450,6 +445,8 @@ bool construction_hit;
 int crossbow_medigun;
 float old_charge_level;
 bool bolt_heal;
+
+OperatingSystem operatingSystem;
 
 //cookies
 Cookie g_hClientMessageCookie;
@@ -592,6 +589,32 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 		return APLRes_SilentFailure;
 	}
 
+	// load the game data now so we can refuse to load if we're on 64-bit
+	GameData gamedata = new GameData("reverts");
+	if (!gamedata) {
+		strcopy(error, err_max, "Cannot load gamedata to determine the operating system");
+		return APLRes_Failure;
+	}
+	int osOffset = gamedata.GetOffset("OperatingSystem");
+	if (osOffset == -1) {
+		delete gamedata;
+		strcopy(error, err_max, "Gamedata has no OperatingSystem value");
+		return APLRes_Failure;
+	}
+	switch (operatingSystem) {
+		case MAC, MAC64: {
+			delete gamedata;
+			strcopy(error, err_max, "This plugin will not work for your operating system");
+			return APLRes_SilentFailure;
+		}
+		case WINDOWS64, LINUX64: {
+			delete gamedata;
+			strcopy(error, err_max, "This plugin doesn't support 64-bit yet");
+			return APLRes_SilentFailure;
+		}
+	}
+
+	delete gamedata;
 	return APLRes_Success;
 }
 
@@ -994,20 +1017,20 @@ public void OnPluginStart() {
 		patch_DroppedWeapon = MemoryPatch.CreateFromConf(conf, "CTFPlayer::DropAmmoPack");
 		patch_RevertIronBomber_PipeHitbox = MemoryPatch.CreateFromConf(conf, "CTFWeaponBaseGun::FirePipeBomb_IronBomberHitboxRevert");
 		patch_RevertCannotDetonateStickiesWhileTaunting = MemoryPatch.CreateFromConf(conf, "CTFPipebombLauncher::SecondaryAttack_RemoveCanAttackCheck");
-#if defined WIN32
-		patch_RevertWranglerSpreadCone_X = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeX");
-		patch_RevertWranglerSpreadCone_Y = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeY");
-		patch_RevertWranglerSpreadCone_Z = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeZ");
-#else
-		patch_RevertWranglerSpreadCone_SSE = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeSSE");
-#endif
+		if (operatingSystem == WINDOWS) {
+			patch_RevertWranglerSpreadCone_X = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeX");
+			patch_RevertWranglerSpreadCone_Y = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeY");
+			patch_RevertWranglerSpreadCone_Z = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeZ");
+		} else {
+			patch_RevertWranglerSpreadCone_SSE = MemoryPatch.CreateFromConf(conf, "CObjectSentrygun::Fire_2DegreeConeSSE");
+		}
 		patch_RevertSteakCapValue = MemoryPatch.CreateFromConf(conf, "CTFPlayer::TeamFortress_CalculateMaxSpeed_SteakCapValue");
 		patch_RevertSteakBoostValue = MemoryPatch.CreateFromConf(conf, "CTFPlayer::TeamFortress_CalculateMaxSpeed_SteakBoostValue");
 
 		AddressOf_g_flMadMilkHealTarget = GetAddressOfCell(g_flMadMilkHealTarget);
-#if !defined WIN32
-		AddressOf_g_flWranglerSpreadTarget = GetAddressOfCell(g_flWranglerSpreadTarget);
-#endif
+		if (operatingSystem != WINDOWS) {
+			AddressOf_g_flWranglerSpreadTarget = GetAddressOfCell(g_flWranglerSpreadTarget);
+		}
 		AddressOf_g_flSteakCapTarget = GetAddressOfCell(g_flSteakCapTarget);
 		AddressOf_g_flSteakBoostTarget = GetAddressOfCell(g_flSteakBoostTarget);
 
@@ -1111,13 +1134,13 @@ public void OnPluginStart() {
 	VALIDATE_PATCH(patch_DroppedWeapon);
 	VALIDATE_PATCH(patch_RevertIronBomber_PipeHitbox);
 	VALIDATE_PATCH(patch_RevertCannotDetonateStickiesWhileTaunting);
-#if defined WIN32
-	VALIDATE_PATCH(patch_RevertWranglerSpreadCone_X);
-	VALIDATE_PATCH(patch_RevertWranglerSpreadCone_Y);
-	VALIDATE_PATCH(patch_RevertWranglerSpreadCone_Z);
-#else
-	VALIDATE_PATCH(patch_RevertWranglerSpreadCone_SSE);
-#endif
+	if (operatingSystem == WINDOWS) {
+		VALIDATE_PATCH(patch_RevertWranglerSpreadCone_X);
+		VALIDATE_PATCH(patch_RevertWranglerSpreadCone_Y);
+		VALIDATE_PATCH(patch_RevertWranglerSpreadCone_Z);
+	} else {
+		VALIDATE_PATCH(patch_RevertWranglerSpreadCone_SSE);
+	}
 	VALIDATE_PATCH(patch_RevertSteakCapValue);
 	VALIDATE_PATCH(patch_RevertSteakBoostValue);
 
@@ -1339,25 +1362,25 @@ void ToggleMemoryPatchReverts(bool enable, int wep_enum) {
 		}
 		case Wep_Wrangler: {
 			if (enable && GetItemVariant(Wep_Wrangler) == 2) {
-#if defined WIN32
-				patch_RevertWranglerSpreadCone_X.Enable();
-				StoreToAddress(patch_RevertWranglerSpreadCone_X.Address + view_as<Address>(6), g_flWranglerSpreadTarget, NumberType_Int32);
-				patch_RevertWranglerSpreadCone_Y.Enable();
-				StoreToAddress(patch_RevertWranglerSpreadCone_Y.Address + view_as<Address>(3), g_flWranglerSpreadTarget, NumberType_Int32);
-				patch_RevertWranglerSpreadCone_Z.Enable();
-				StoreToAddress(patch_RevertWranglerSpreadCone_Z.Address + view_as<Address>(3), g_flWranglerSpreadTarget, NumberType_Int32);
-#else
-				patch_RevertWranglerSpreadCone_SSE.Enable();
-				StoreToAddress(patch_RevertWranglerSpreadCone_SSE.Address + view_as<Address>(4), AddressOf_g_flWranglerSpreadTarget, NumberType_Int32);
-#endif
+				if (operatingSystem == WINDOWS) {
+					patch_RevertWranglerSpreadCone_X.Enable();
+					StoreToAddress(patch_RevertWranglerSpreadCone_X.Address + view_as<Address>(6), g_flWranglerSpreadTarget, NumberType_Int32);
+					patch_RevertWranglerSpreadCone_Y.Enable();
+					StoreToAddress(patch_RevertWranglerSpreadCone_Y.Address + view_as<Address>(3), g_flWranglerSpreadTarget, NumberType_Int32);
+					patch_RevertWranglerSpreadCone_Z.Enable();
+					StoreToAddress(patch_RevertWranglerSpreadCone_Z.Address + view_as<Address>(3), g_flWranglerSpreadTarget, NumberType_Int32);
+				} else {
+					patch_RevertWranglerSpreadCone_SSE.Enable();
+					StoreToAddress(patch_RevertWranglerSpreadCone_SSE.Address + view_as<Address>(4), AddressOf_g_flWranglerSpreadTarget, NumberType_Int32);
+				}
 			} else {
-#if defined WIN32
-				patch_RevertWranglerSpreadCone_X.Disable();
-				patch_RevertWranglerSpreadCone_Y.Disable();
-				patch_RevertWranglerSpreadCone_Z.Disable();
-#else
-				patch_RevertWranglerSpreadCone_SSE.Disable();
-#endif
+				if (operatingSystem == WINDOWS) {
+					patch_RevertWranglerSpreadCone_X.Disable();
+					patch_RevertWranglerSpreadCone_Y.Disable();
+					patch_RevertWranglerSpreadCone_Z.Disable();
+				} else {
+					patch_RevertWranglerSpreadCone_SSE.Disable();
+				}
 			}
 		}
 		case Wep_BuffaloSteak: {

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -41,10 +41,6 @@
 #define PLUGIN_AUTHOR "Bakugo, NotnHeavy, random, huutti, VerdiusArcana, MindfulProtons, EricZhang456"
 
 #define PLUGIN_VERSION_NUM "2.0.3"
-// Add a OS suffix if Memorypatch reverts are used
-// to make it easier to see which OS the plugin is compiled for. 
-// To server owners, before you raise hell, do: sm plugins list 
-// and check that you compiled for the correct OS.
 #if defined MEMORY_PATCHES
 #define PLUGIN_VERSION PLUGIN_VERSION_NUM
 #else


### PR DESCRIPTION
### Summary of changes
Use gamedata to detect OS. No need for split Windows and Linux versions anymore.

### Testing Attestation
N/A

### Description of testing
N/A

### Other Info
N/A